### PR TITLE
Removed MapQuest OpenAerial layer

### DIFF
--- a/data/imagery.json
+++ b/data/imagery.json
@@ -1,11 +1,5 @@
 [
   {
-    "name": "MapQuest Open Aerial",
-    "type": "tms",
-    "template": "http://oatile{switch:1,2,3,4}.mqcdn.com/tiles/1.0.0/sat/{zoom}/{x}/{y}.png",
-    "default": true
-  },
-  {
     "name": "OpenHistoricalMap",
     "type": "tms",
     "description": "The default OpenHistoricalMap layer.",


### PR DESCRIPTION
MapQuest OpenAerial layer removed from layer settings because support has been disabled a while ago.