### PR TITLE
Date Range panel & functionality with Map Features

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -804,12 +804,13 @@ en:
       description: Full Fill
       tooltip: "Areas are drawn fully filled."
   date_ranges:
+    title: Date Range
     start_date:
-      description: Start Date
-      tooltip: The start of your specified date range
+      description: Start Year
+      tooltip: The start year, as an integer, negatives OK
     end_date:
-      description: End Date
-      tooltip: The end of your specified date range
+      description: End Year
+      tooltip: The end year, as an integer, negatives OK
   settings:
     custom_background:
       tooltip: Edit custom background

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -741,9 +741,6 @@ en:
         title: "Panoramic Photos"
         tooltip: "360° photos"
   feature:
-    date_range:
-      description: Show features from all dates
-      tooltip: "When selected, shows all feature dates, when unselected only shows the specified dates"
     points:
       description: Points
       tooltip: "Points of Interest"
@@ -808,9 +805,11 @@ en:
     start_date:
       description: Start Year
       tooltip: The start year, as an integer, negatives OK
+      placeholder: e.g. 1487
     end_date:
       description: End Year
       tooltip: The end year, as an integer, negatives OK
+      placeholder: e.g. 1976
   settings:
     custom_background:
       tooltip: Edit custom background

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1016,13 +1016,14 @@
             }
         },
         "date_ranges": {
+            "title": "Date Range",
             "start_date": {
-                "description": "Start Date",
-                "tooltip": "The start of your specified date range"
+                "description": "Start Year",
+                "tooltip": "The start year, as an integer, negatives OK"
             },
             "end_date": {
-                "description": "End Date",
-                "tooltip": "The end of your specified date range"
+                "description": "End Year",
+                "tooltip": "The end year, as an integer, negatives OK"
             }
         },
         "settings": {
@@ -10609,6 +10610,41 @@
                 "description": "Esri archive imagery that may be clearer and more accurate than the default layer.",
                 "name": "Esri World Imagery (Clarity) Beta"
             },
+            "Geoportal2-PL-HighResolution-aerial_image_WMS": {
+                "attribution": {
+                    "text": "Główny Urząd Geodezji i Kartografii"
+                },
+                "description": "Ortofotomapa o rozdzielczości 10 cm lub większej. Dane posortowane są wg rozdzielczości a następnie wg aktualności, np. arkusz z 2012 roku o rozdzielczości 8 cm przysłania arkusz z 2019 roku o rozdzielczości 10 cm.",
+                "name": "Geoportal 2: High Resolution Orthophotomap (aerial image)"
+            },
+            "Geoportal2-PL-Streets_WMS": {
+                "attribution": {
+                    "text": "Główny Urząd Geodezji i Kartografii"
+                },
+                "description": "Usługa przeglądania WMS Krajowa Integracja Numeracji Adresowej umożliwiająca pobieranie obrazów mapowych utworzonych na podstawie danych przestrzennych z Państwowego Rejestru Granic w zakresie ewidencji ulic i adresów.",
+                "name": "Geoportal 2 Nazwy ulic"
+            },
+            "Geoportal2-PL-addres_points_WMS": {
+                "attribution": {
+                    "text": "Główny Urząd Geodezji i Kartografii"
+                },
+                "description": "Usługa przeglądania WMS Krajowa Integracja Numeracji Adresowej umożliwiająca pobieranie obrazów mapowych utworzonych na podstawie danych przestrzennych z Państwowego Rejestru Granic w zakresie ewidencji ulic i adresów.",
+                "name": "Geoportal 2: Punkty adresowe"
+            },
+            "Geoportal2-PL-aerial_image_WMS": {
+                "attribution": {
+                    "text": "Główny Urząd Geodezji i Kartografii"
+                },
+                "description": "Usługa przeglądania (Web Map Service,WMS) umożliwiająca przeglądanie ortofotomap dla obszaru Polski. Dane udostępniane za pomocą tej usługi stanowią ortofotomapę wykonaną ze zdjęć lotniczych. Usługa oferuje wsparcie dla interfejsu WMS 1.3.0.",
+                "name": "Geoportal 2: Orthophotomap (aerial image)"
+            },
+            "Geoportal2-PL-buildings_WMS": {
+                "attribution": {
+                    "text": "Główny Urząd Geodezji i Kartografii"
+                },
+                "description": "Usługa Krajowa Integracja Ewidencji Gruntów jest usługą zbiorczą prezentacji danych ewidencyjnych pochodzących bezpośrednio z jednostek szczebla powiatowego. Usługa zawiera jedynie dane tych jednostek, które dysponują usługą WMS o odpowiednich parametrach i zdecydowały się włączyć swoją usługę WMS do usługi zbiorczej KrajowaIntegracjaEwidencjiGruntow.",
+                "name": "Geoportal 2: Ewidencja budynków WMS"
+            },
             "MAPNIK": {
                 "attribution": {
                     "text": "© OpenStreetMap contributors, CC-BY-SA 2.0"
@@ -10622,6 +10658,13 @@
                 },
                 "description": "Satellite and aerial imagery.",
                 "name": "Mapbox Satellite"
+            },
+            "OSMUK-Cadastral-Parcels": {
+                "attribution": {
+                    "text": "Contains public sector information licensed under the Open Government Licence v3.0."
+                },
+                "description": "Perfectly aligned cadastral (land registry) parcels in Great Britain",
+                "name": "OSMUK Cadastral Parcels"
             },
             "OSM_Inspector-Addresses": {
                 "attribution": {
@@ -10671,10 +10714,6 @@
             "SPW_PICC": {
                 "name": "SPW(allonie) PICC numerical imagery"
             },
-            "US-TIGER-Roads-2014": {
-                "description": "At zoom level 16+, public domain map data from the US Census. At lower zooms, only changes since 2006 minus changes already incorporated into OpenStreetMap",
-                "name": "TIGER Roads 2014"
-            },
             "US-TIGER-Roads-2017": {
                 "description": "Yellow = Public domain map data from the US Census. Red = Data not found in OpenStreetMap",
                 "name": "TIGER Roads 2017"
@@ -10686,6 +10725,10 @@
             "US-TIGER-Roads-2019": {
                 "description": "Yellow = Public domain map data from the US Census. Red = Data not found in OpenStreetMap",
                 "name": "TIGER Roads 2019"
+            },
+            "US-TIGER-Roads-2020": {
+                "description": "Yellow = Public domain map data from the US Census. Red = Data not found in OpenStreetMap",
+                "name": "TIGER Roads 2020"
             },
             "USDA-NAIP": {
                 "description": "The most recent year of DOQQs from the National Agriculture Imagery Program (NAIP) for each state in the contiguous United States.",
@@ -10803,12 +10846,33 @@
                 "description": "The city map is an overview map that describes Gothenburg. It contains general information about land, communications, hydrography, buildings, address numbers and street names, administrative division and other orientation text.",
                 "name": "Gothenburg City map"
             },
+            "gothenburg-dtm-2017": {
+                "attribution": {
+                    "text": "© Gothenburg municipality, CC0"
+                },
+                "description": "Web map service presenting hillshade and slope based on the 2017 elevation model for City of Gothenburg. Resolution 0.5 meters per pixel.",
+                "name": "Gothenburg Hillshade"
+            },
             "gothenburg-ortho": {
                 "attribution": {
                     "text": "© Gothenburg municipality, CC0"
                 },
                 "description": "Orthophoto for Gothenburg municipality",
-                "name": "Gothenburg Orthophoto"
+                "name": "Gothenburg Orthophoto 2015"
+            },
+            "gothenburg-ortho_2017": {
+                "attribution": {
+                    "text": "© Gothenburg municipality, CC0"
+                },
+                "description": "Orthophoto for Gothenburg municipality",
+                "name": "Gothenburg Orthophoto 2017"
+            },
+            "gothenburg-ortho_2019": {
+                "attribution": {
+                    "text": "© Gothenburg municipality, CC0"
+                },
+                "description": "Orthophoto for Gothenburg municipality",
+                "name": "Gothenburg Orthophoto 2019"
             },
             "gsi.go.jp_airphoto": {
                 "attribution": {
@@ -10858,6 +10922,13 @@
                 },
                 "description": "Orthophotos for urban areas of the municipality of Kalmar 2018",
                 "name": "Kalmar Urban Orthophoto 2018"
+            },
+            "kalmar-orto-2020": {
+                "attribution": {
+                    "text": "© Kalmar municipality"
+                },
+                "description": "Orthophotos for urban areas of the municipality of Kalmar 2020",
+                "name": "Kalmar Urban Orthophoto 2020"
             },
             "kelkkareitit": {
                 "attribution": {

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -100,45 +100,6 @@ export function rendererFeatures(context) {
         };
     }
 
-    defineRule('date_range', function isWithinRange(tags) {
-      // Function to parse time (YYYY-MM-DD) to an INT
-      var valueToInt = function(value) {
-        return (typeof value === 'string') ?
-          parseInt(value.replace(/-/g, ''), 10) :
-          0;
-      };
-
-      // Convert the date range from the entity to a number
-      var entityRange = {
-        'start_date': valueToInt(tags.start_date),
-        'end_date': valueToInt(tags.end_date)
-      };
-
-      // These will be pulled from the on-screen controls
-      // Maybe put them in browser storage?
-      var selectedRange = {
-        'start_date': -Infinity, //valueToInt(entity['start_date']),
-        'end_date': Infinity // valueToInt(entity['end_date'])
-      };
-      if (context.features().dateRange) {
-        selectedRange.start_date = context.features().dateRange[0];
-        selectedRange.end_date = context.features().dateRange[1];
-      }
-
-    //   // console.log('v---------------------------------------------v');
-    //   // console.log('selectedRange', selectedRange);
-    //   // console.log('entityRange', entityRange);
-    //   // console.log('Return', !((selectedRange['start_date'] <= entityRange['end_date']) && (entityRange['start_date'] <= selectedRange['end_date'])));
-    //   // console.log('^---------------------------------------------^');
-
-    //   // Within range if:
-    //   //    the entity started before the selected range started
-    //   //    and also ended after the selected range started
-      return !((selectedRange.start_date <= entityRange.end_date) &&
-        (entityRange.start_date <= selectedRange.end_date));
-
-    });
-
     defineRule('points', function isPoint(tags, geometry) {
         return geometry === 'point';
     }, 200);
@@ -480,6 +441,24 @@ export function rendererFeatures(context) {
     };
 
 
+    features.checkDateFilter = function (entity) {
+        // filter by Date Range, see modules/ui/sections/map_daterange.js for the UI in a separate panel
+        // during startup or during transition, simply return true if no date
+        if (! context.features().dateRange) return true;
+        const fmin = context.features().dateRange[0];
+        const fmax = context.features().dateRange[1];
+
+        // strip the start/end year to integer, and treat null as meaning infinite/eternal start/end
+        const tmin = entity.tags.start_date ? parseInt(entity.tags.start_date.substr(0, 4)) : -Infinity;
+        const tmax = entity.tags.end_date ? parseInt(entity.tags.end_date.substr(0, 4)) : Infinity;
+
+        // the comparison
+        const isinrange = ! ( (tmax < fmin) || (tmin > fmax) );
+        // if (entity.tags.name == 'Occidental Hotel') console.debug(`features.checkDateFilter: ${fmin}-${fmax} vs ${tmin}-${tmax} = ${isinrange}`);
+        return isinrange;
+    };
+
+
     features.getParents = function(entity, resolver, geometry) {
         if (geometry === 'point') return [];
 
@@ -522,6 +501,9 @@ export function rendererFeatures(context) {
         if (!_hidden.length) return false;
         if (!entity.version) return false;
         if (_forceVisible[entity.id]) return false;
+
+        const matchesdatefilter = features.checkDateFilter(entity);
+        if (! matchesdatefilter) return true;
 
         var matches = Object.keys(features.getMatches(entity, resolver, geometry));
         return matches.length && matches.every(function(k) { return features.hidden(k); });

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -449,13 +449,24 @@ export function rendererFeatures(context) {
         const fmax = context.features().dateRange[1];
 
         // strip the start/end year to integer, and treat null as meaning infinite/eternal start/end
-        const tmin = entity.tags.start_date ? parseInt(entity.tags.start_date.substr(0, 4)) : -Infinity;
-        const tmax = entity.tags.end_date ? parseInt(entity.tags.end_date.substr(0, 4)) : Infinity;
+        const tmin = features.parseDateStringToIntegerYear(entity.tags.start_date, -Infinity);
+        const tmax = features.parseDateStringToIntegerYear(entity.tags.end_date, Infinity);
 
         // the comparison
         const isinrange = ! ( (tmax < fmin) || (tmin > fmax) );
-        // if (entity.tags.name == 'Occidental Hotel') console.debug(`features.checkDateFilter: ${fmin}-${fmax} vs ${tmin}-${tmax} = ${isinrange}`);
         return isinrange;
+    };
+
+
+    features.parseDateStringToIntegerYear = function(datestring, ifblank) {
+        // expect a date string in ISO format: yyyy-mm-dd
+        // handle negative dates -yyyy-mm-dd and partial dates yyyy-mm and yyyy
+        // and supply a failover if the date is blank/unparseable
+        if (! datestring) return ifblank;  // instant fail
+
+        const getyear = /^(\-?\d+)/;
+        const yearbit = datestring.match(getyear);
+        return yearbit ? parseInt(yearbit) : ifblank;
     };
 
 

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -15,7 +15,7 @@ import { utilArrayChunk, utilArrayGroupBy, utilArrayUniq, utilRebind, utilTiler,
 
 var tiler = utilTiler();
 var dispatch = d3_dispatch('apiStatusChange', 'authLoading', 'authDone', 'change', 'loading', 'loaded', 'loadedNotes');
-var urlroot = 'https://www.openstreetmap.org';
+var urlroot = 'https://www.openhistoricalmap.org';
 var oauth = osmAuth({
     url: urlroot,
     oauth_consumer_key: '5A043yRSEugj4DJ5TljuapfnrflWDte8jTOcWLlT',

--- a/modules/ui/panes/map_data.js
+++ b/modules/ui/panes/map_data.js
@@ -6,6 +6,7 @@ import { uiSectionDataLayers } from '../sections/data_layers';
 import { uiSectionMapFeatures } from '../sections/map_features';
 import { uiSectionMapStyleOptions } from '../sections/map_style_options';
 import { uiSectionPhotoOverlays } from '../sections/photo_overlays';
+import { uiSectionDateRange } from '../sections/map_daterange';
 
 export function uiPaneMapData(context) {
 
@@ -16,6 +17,7 @@ export function uiPaneMapData(context) {
         .iconName('iD-icon-data')
         .sections([
             uiSectionDataLayers(context),
+            uiSectionDateRange(context),
             uiSectionPhotoOverlays(context),
             uiSectionMapStyleOptions(context),
             uiSectionMapFeatures(context)

--- a/modules/ui/panes/map_data.js
+++ b/modules/ui/panes/map_data.js
@@ -17,9 +17,9 @@ export function uiPaneMapData(context) {
         .iconName('iD-icon-data')
         .sections([
             uiSectionDataLayers(context),
-            uiSectionDateRange(context),
             uiSectionPhotoOverlays(context),
             uiSectionMapStyleOptions(context),
+            uiSectionDateRange(context),
             uiSectionMapFeatures(context)
         ]);
 

--- a/modules/ui/sections/map_daterange.js
+++ b/modules/ui/sections/map_daterange.js
@@ -1,0 +1,27 @@
+import {
+    select as d3_select
+} from 'd3-selection';
+
+import { t } from '../../core/localizer';
+import { uiTooltip } from '../tooltip';
+import { uiSection } from '../section';
+
+export function uiSectionDateRange(context) {
+
+    var section = uiSection('date_ranges', context)
+        .title(t('date_ranges.title'))
+        .disclosureContent(renderDisclosureContent)
+        .expandedByDefault(false);
+
+    function renderDisclosureContent(selection) {
+        var container = selection.selectAll('.date_ranges-container')
+            .data([0]);
+
+        container.enter()
+            .append('div')
+            .attr('class', 'map-data-date-ranges')
+            .merge(container)
+    }
+
+   return section;
+}

--- a/modules/ui/sections/map_daterange.js
+++ b/modules/ui/sections/map_daterange.js
@@ -1,27 +1,183 @@
-import {
-    select as d3_select
-} from 'd3-selection';
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
 
 import { t } from '../../core/localizer';
 import { uiTooltip } from '../tooltip';
 import { uiSection } from '../section';
 
-export function uiSectionDateRange(context) {
+const MIN_YEAR = -4000;
+const MAX_YEAR = (new Date()).getFullYear();
 
-    var section = uiSection('date_ranges', context)
+const PLUSMINUS_STYLES = [
+    { name: 'font-weight', value: 'bold' },
+    { name: 'font-size', value: '200%' },
+    { name: 'padding', value: '0 5px' },
+];
+const INPUT_STYLES = [
+    { name: 'width', value: '100px' },
+    { name: 'text-align', value: 'center' },
+];
+const LABEL_STYLES = [
+    { name: 'font-weight', value: 'bold' },
+    { name: 'display', value: 'inline-block' },
+    { name: 'width', value: '75px' },
+];
+
+export function uiSectionDateRange(context) {
+    // despite appearing as a separate panel, Map Features does the real filtering
+    // see applyDateRange() here where the filter value is set
+    // see modules/renderer/features.js checkDateFilter() which applies the filters
+
+    const section = uiSection('date_ranges', context)
         .title(t('date_ranges.title'))
         .disclosureContent(renderDisclosureContent)
         .expandedByDefault(false);
 
     function renderDisclosureContent(selection) {
-        var container = selection.selectAll('.date_ranges-container')
-            .data([0]);
+        const container = selection.selectAll('.date_ranges-container').data([0]);
 
+        // min year: - button, year input, + button
+        const mindate_label = container.enter()
+            .append('label')
+            .html(t('date_ranges.start_date.description'))
+            .merge(container);
+        const mindate_minus = container.enter()
+            .append('button')
+            .html('-')
+            .call(uiTooltip()
+                .title(t('date_ranges.start_date.tooltip')).placement('bottom')
+            )
+            .merge(container);
+        const mindate_input = container.enter()
+            .append('input')
+            .attr('type', 'number')
+            .attr('min', MIN_YEAR)
+            .attr('max', MAX_YEAR)
+            .attr('step', 1)
+            .attr('value', MIN_YEAR)
+            .attr('title', t('date_ranges.start_date.tooltip'))
+            .attr('placeholder', t('date_ranges.start_date.placeholder'))
+            .merge(container);
+        const mindate_plus = container.enter()
+            .append('button')
+            .html('+')
+            .call(uiTooltip()
+                .title(t('date_ranges.start_date.tooltip')).placement('bottom')
+            )
+            .merge(container);
+
+        // line break
         container.enter()
-            .append('div')
-            .attr('class', 'map-data-date-ranges')
-            .merge(container)
+            .append('br')
+            .merge(container);
+
+        // max year: - button, year input, + button
+        const maxdate_label = container.enter()
+            .append('label')
+            .html(t('date_ranges.end_date.description'))
+            .merge(container);
+        const maxdate_minus = container.enter()
+            .append('button')
+            .html('-')
+            .call(uiTooltip()
+                .title(t('date_ranges.end_date.tooltip')).placement('bottom')
+            )
+            .merge(container);
+        const maxdate_input = container.enter()  // we will refer to this widget by its name attribute to fetch our date range
+            .append('input')
+            .attr('type', 'number')
+            .attr('min', MIN_YEAR)
+            .attr('max', MAX_YEAR)
+            .attr('step', 1)
+            .attr('value', MAX_YEAR)
+            .attr('title', t('date_ranges.end_date.tooltip'))
+            .attr('placeholder', t('date_ranges.end_date.placeholder'))
+            .merge(container);
+        const maxdate_plus = container.enter()
+            .append('button')
+            .html('+')
+            .call(uiTooltip()
+                .title(t('date_ranges.end_date.tooltip')).placement('bottom')
+            )
+            .merge(container);
+
+        // apply styles
+        PLUSMINUS_STYLES.forEach(function (style) {
+            mindate_plus.style(style.name, style.value);
+            mindate_minus.style(style.name, style.value);
+            maxdate_minus.style(style.name, style.value);
+            maxdate_plus.style(style.name, style.value);
+        });
+        INPUT_STYLES.forEach(function (style) {
+            mindate_input.style(style.name, style.value);
+            maxdate_input.style(style.name, style.value);
+        });
+        LABEL_STYLES.forEach(function (style) {
+            mindate_label.style(style.name, style.value);
+            maxdate_label.style(style.name, style.value);
+        });
+
+        // event handlers for the +/- buttons to change year
+        mindate_minus.on('click', function () {
+            const year = parseInt(mindate_input.property('value')) - 1;
+            const min = parseInt(mindate_input.property('min'));
+            if (year >= min) mindate_input.property('value', year).dispatch('change');
+        });
+        mindate_plus.on('click', function () {
+            const year = parseInt(mindate_input.property('value')) + 1;
+            const max = parseInt(mindate_input.property('max'));
+            if (year <= max) mindate_input.property('value', year).dispatch('change');
+        });
+        maxdate_minus.on('click', function () {
+            const year = parseInt(maxdate_input.property('value')) - 1;
+            const min = parseInt(maxdate_input.property('min'));
+            if (year >= min) maxdate_input.property('value', year).dispatch('change');
+        });
+        maxdate_plus.on('click', function () {
+            const year = parseInt(maxdate_input.property('value')) + 1;
+            const max = parseInt(maxdate_input.property('max'));
+            if (year <= max) maxdate_input.property('value', year).dispatch('change');
+        });
+
+        // event handler for change event
+        // intercept invalid & blank and correct them to our hardcoded in/max
+        // then cause a re-filter/redraw
+        function applyDateRange() {
+            const minyear = parseInt(mindate_input.property('value'));
+            const maxyear = parseInt(maxdate_input.property('value'));
+
+            context.features().dateRange = [minyear, maxyear];
+            context.flush();
+        }
+
+        function ensureValidInputs() {
+            const minyear = parseInt(mindate_input.property('value'));
+            const maxyear = parseInt(maxdate_input.property('value'));
+
+            if (! minyear || isNaN(minyear) || minyear < MIN_YEAR || minyear > MAX_YEAR) {
+                mindate_input.property('value', MIN_YEAR);
+            }
+            if (! maxyear || isNaN(maxyear) || maxyear < MIN_YEAR || maxyear > MAX_YEAR) {
+                maxdate_input.property('value', MAX_YEAR);
+            }
+
+            if (minyear > maxyear) {
+                maxdate_input.property('value', minyear);
+            }
+        }
+
+        mindate_input.on('change', function () {
+            ensureValidInputs();
+            applyDateRange();
+        });
+        maxdate_input.on('change', function () {
+            ensureValidInputs();
+            applyDateRange();
+        });
+
+        // apply now so we have context.dateRange always defined
+        applyDateRange();
     }
 
-   return section;
+    return section;
 }


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/93 for the issue of getting iD to work with OHM, then reinstating a Date Range filter.

Changes from gregallensworth:
* fleshed out Date Range panel as two text boxes, with +- behaviors, validity checks, etc.
* moved Date Range panel downward to be adjacent with Map Features, since the two interact
* Map Features. removed "Show features from all dates" and reworked `date_range` to be ANDed with the `getMatches()` results instead of treated as one of the OR filters
* added support for URL params saved from Date Range changes, and loaded into Date Range at startup

Changes from danrademacher:
* endpoint URL in modules/services/osm.js changed from OSM to OHM

Other changes, provenance pending:
* data attributions in dist/locales/en.json
