### PR TITLE
point iD to ohm-editor-layer-index instead of the original osm index

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -15,7 +15,7 @@ To report an issue with missing or cloudy imagery:
 * _For Bing Satellite layer:_ Open the location in [Bing Maps](https://www.bing.com/maps), click the "Feedback" button and choose "Report a map problem" option.
 * _For Esri World Imagery:_ You can open a new issue using the [Imagery Map Feedback tool](https://www.arcgis.com/home/item.html?id=ebdfa4146680410bb952c7d532ea5407).
 
-iD's list of available background imagery sources come from the [editor-layer-index](https://github.com/osmlab/editor-layer-index)
+iD's list of available background imagery sources come from the [ohm-editor-layer-index](https://github.com/openhistoricalmap/ohm-editor-layer-index)
 project.  If you know of a more recent imagery source that is licensed for this use,
 please open a request there with the link and license details.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ iD also bundles portions of the following open source software.
 
 * [D3.js (BSD-3-Clause)](https://github.com/d3/d3)
 * [CLDR (Unicode Consortium Terms of Use)](https://github.com/unicode-cldr/cldr-json)
-* [editor-layer-index (CC-BY-SA 3.0)](https://github.com/osmlab/editor-layer-index)
+* [ohm-editor-layer-index (CC-BY-SA 3.0)](https://github.com/openhistoricalmap/ohm-editor-layer-index)
 * [Font Awesome (CC-BY 4.0)](https://fontawesome.com/license)
 * [Maki (CC0 1.0)](https://github.com/mapbox/maki)
 * [Mapillary JS (MIT)](https://github.com/mapillary/mapillary-js)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ on the iD project, and then create this file with contents like<br><pre>
 #### Update `develop` branch
 ```bash
 $  git checkout develop
-$  rm -rf node_modules/editor-layer-index/
+$  rm -rf node_modules/ohm-editor-layer-index/
 $  npm install
 $  npm run imagery
 $  npm run all

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "colors": "^1.1.2",
     "concat-files": "^0.1.1",
     "d3": "~5.16.0",
-    "editor-layer-index": "github:osmlab/editor-layer-index#gh-pages",
+    "ohm-editor-layer-index": "github:openhistoricalmap/ohm-editor-layer-index#dist",
     "eslint": "^7.1.0",
     "gaze": "^1.1.3",
     "glob": "^7.1.0",

--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -797,7 +797,7 @@ function translationsToYAML(translations) {
 
 function writeEnJson(tstrings) {
   const readCoreYaml = fs.readFileSync('data/core.yaml', 'utf8');
-  const readImagery = fs.readFileSync('node_modules/editor-layer-index/i18n/en.yaml', 'utf8');
+  const readImagery = fs.readFileSync('node_modules/ohm-editor-layer-index/i18n/en.yaml', 'utf8');
   const readCommunity = fs.readFileSync('node_modules/osm-community-index/i18n/en.yaml', 'utf8');
   const readManualImagery = fs.readFileSync('data/manual_imagery.json', 'utf8');
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,9 +30,9 @@ if [[ "${rev}" != "${orig}" ]] ; then
 fi
 
 # pull latest imagery
-rm -rf node_modules/editor-layer-index/
-git clone https://github.com/osmlab/editor-layer-index.git node_modules/editor-layer-index > /dev/null 2>&1
-rm -rf node_modules/editor-layer-index/.git/
+rm -rf node_modules/ohm-editor-layer-index/
+git clone https://github.com/openhistoricalmap/ohm-editor-layer-index.git node_modules/ohm-editor-layer-index > /dev/null 2>&1
+rm -rf node_modules/ohm-editor-layer-index/.git/
 
 # build everything
 npm run imagery

--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const fs = require('fs');
-let sources = require('editor-layer-index/imagery.json');
+let sources = require('ohm-editor-layer-index/imagery.json');
 const prettyStringify = require('json-stringify-pretty-compact');
 
 if (fs.existsSync('./data/manual_imagery.json')) {
@@ -9,10 +9,6 @@ if (fs.existsSync('./data/manual_imagery.json')) {
 }
 
 let imagery = [];
-
-// ignore imagery more than 20 years old..
-let cutoffDate = new Date();
-cutoffDate.setFullYear(cutoffDate.getFullYear() - 20);
 
 
 const discard = {
@@ -115,7 +111,6 @@ sources.forEach(source => {
     endDate = new Date(source.end_date);
     isValid = !isNaN(endDate.getTime());
     if (isValid) {
-      if (endDate <= cutoffDate) return;  // too old
       im.endDate = endDate;
     }
   }


### PR DESCRIPTION
I'm not sure exactly how this fork is managed and kept up to date etc, so please let me know if I've done this wrong.

Some for the base branch, I'm not sure if this should target staging or not?

In the editor-layer-index fork I've temporarily disabled translations until we can set it up, looks like this switch might not work until that's done.