### PR TITLE
Allow ways to cross when separated temporally

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1742,8 +1742,8 @@ en:
       message: "Two points in {way} are very close together"
       reference: "Redundant points in a way should be merged or moved apart."
       detached:
-        message: "{feature} is too close to {feature2}"
-        reference: "Separate points should not share a location."
+        message: "{feature} is too close to {feature2} during the same time period"
+        reference: "Separate points should not share a location if their date ranges overlap."
     crossing_ways:
       title: Crossing Ways
       message: "{feature} crosses {feature2} during the same time period"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1728,12 +1728,12 @@ en:
       annotation: Fixed several validation issues.
     almost_junction:
       title: Almost Junctions
-      message: "{feature} is very close but not connected to {feature2}"
-      tip: "Find features that should possibly be connected to other nearby features"
+      message: "{feature} is very close but not connected to {feature2} during the same time period"
+      tip: "Find features that should possibly be connected to other nearby features during the same time period"
       self:
         message: "{feature} ends very close to itself but does not reconnect"
       highway-highway:
-        reference: Intersecting highways should share a junction vertex.
+        reference: Highways that intersect and have overlapping date ranges should share a junction vertex.
     area_as_point:
       message: '{feature} should be an area, not a point'
     close_nodes:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1746,40 +1746,40 @@ en:
         reference: "Separate points should not share a location."
     crossing_ways:
       title: Crossing Ways
-      message: "{feature} crosses {feature2}"
-      tip: "Find features that incorrectly cross over one another"
+      message: "{feature} crosses {feature2} during the same time period"
+      tip: "Find features that incorrectly cross over one another during the same time period"
       building-building:
-        reference: "Buildings should not intersect except on different layers."
+        reference: "Buildings should not intersect except on different layers or within different date ranges."
       building-highway:
-        reference: "Highways crossing buildings should use bridges, tunnels, or different layers."
+        reference: "Highways crossing buildings should use bridges, tunnels, or different layers or have different date ranges."
       building-railway:
-        reference: "Railways crossing buildings should use bridges, tunnels, or different layers."
+        reference: "Railways crossing buildings should use bridges, tunnels, or different layers or have different date ranges."
       building-waterway:
-        reference: "Waterways crossing buildings should use tunnels or different layers."
+        reference: "Waterways crossing buildings should use tunnels or different layers or have different date ranges."
       highway-highway:
-        reference: "Crossing highways should use bridges, tunnels, or intersections."
+        reference: "Crossing highways should use bridges, tunnels, or intersections or have different date ranges."
       highway-railway:
-        reference: "Highways crossing railways should use bridges, tunnels, or level crossings."
+        reference: "Highways crossing railways should use bridges, tunnels, or level crossings or have different date ranges."
       highway-waterway:
-        reference: "Highways crossing waterways should use bridges, tunnels, or fords."
+        reference: "Highways crossing waterways should use bridges, tunnels, or fords or have different date ranges."
       railway-railway:
-        reference: "Crossing railways should be connected or use bridges or tunnels."
+        reference: "Crossing railways should be connected, use bridges or tunnels, or have different date ranges."
       railway-waterway:
-        reference: "Railways crossing waterways should use bridges or tunnels."
+        reference: "Railways crossing waterways should use bridges or tunnels or have different date ranges."
       waterway-waterway:
-        reference: "Crossing waterways should be connected or use tunnels."
+        reference: "Crossing waterways should be connected, use tunnels, or have different date ranges."
       tunnel-tunnel:
-        reference: "Crossing tunnels should use different layers."
+        reference: "Crossing tunnels should use different layers or have different date ranges."
       tunnel-tunnel_connectable:
-        reference: "Crossing tunnels should be connected or use different layers."
+        reference: "Crossing tunnels should be connected, use different layers, or have different date ranges."
       bridge-bridge:
-        reference: "Crossing bridges should use different layers."
+        reference: "Crossing bridges should use different layers or have different date ranges."
       bridge-bridge_connectable:
-        reference: "Crossing bridges should be connected or use different layers."
+        reference: "Crossing bridges should be connected, use different layers, or have different date ranges."
       indoor-indoor:
-        reference: "Crossing indoor features should use different levels."
+        reference: "Crossing indoor features should use different levels or have different date ranges."
       indoor-indoor_connectable:
-        reference: "Crossing indoor features should be connected or use different levels."
+        reference: "Crossing indoor features should be connected, use different levels, or have different date ranges."
     disconnected_way:
       title: Disconnected Ways
       tip: "Find unroutable roads, paths, and ferry routes"
@@ -1916,6 +1916,8 @@ en:
         annotation: Added a tunnel.
       address_the_concern:
         title: Address the concern
+      change_date_range:
+        title: Change the Start Date and End Date
       connect_almost_junction:
         annotation: Connected very close features.
       connect_crossing_features:

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -14,6 +14,7 @@ export { utilArrayUniqBy } from './array';
 export { utilAsyncMap } from './util';
 export { utilCleanTags } from './clean_tags';
 export { utilCombinedTags } from './util';
+export { utilDatesOverlap } from './util';
 export { utilDeepMemberSelector } from './util';
 export { utilDetect } from './detect';
 export { utilDisplayName } from './util';

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -629,3 +629,45 @@ export function utilOldestID(ids) {
 
     return ids[oldestIDIndex];
 }
+
+// Returns whether two date component arrays represent the same date.
+// A date component array contains the full date, followed by year, month, day.
+// Dates are only compared to the lowest common precision.
+function isSameDate(date1, date2) {
+    return isBefore(date1, date2) && isAfter(date1, date2);
+}
+
+function isBefore(date1, date2) {
+    if (date1[1] > date2[1]) return false;
+    if (date1[2] && date2[2] && date1[2] > date2[2]) return false;
+    if (date1[3] && date2[3] && date1[3] > date2[3]) return false;
+    return true;
+}
+
+function isAfter(date1, date2) {
+    if (date1[1] < date2[1]) return false;
+    if (date1[2] && date2[2] && date1[2] < date2[2]) return false;
+    if (date1[3] && date2[3] && date1[3] < date2[3]) return false;
+    return true;
+}
+
+// Returns whether the two sets of tags overlap temporally.
+export function utilDatesOverlap(tags1, tags2) {
+    // If the feature has a valid start date but no valid end date, assume it
+    // starts at the beginning of time.
+    var dateRegex = /^(-?\d{1,4})(?:-(\d\d))?(?:-(\d\d))?$/;
+    var minDate = ['-9999', '-9999'],
+        maxDate = ['9999', '9999'],
+        start1 = (tags1.start_date || '').match(dateRegex) || minDate,
+        start2 = (tags2.start_date || '').match(dateRegex) || minDate,
+        end1 = (tags1.end_date || '').match(dateRegex) || maxDate,
+        end2 = (tags2.end_date || '').match(dateRegex) || maxDate;
+
+    // No overlap if one feature ends at the very moment that another begins.
+    if (isSameDate(end1, start2) || isSameDate(end2, start1)) return false;
+
+    return ((isAfter(start1, start2) && isBefore(start1, end2)) ||
+            (isAfter(start2, start1) && isBefore(start2, end1)) ||
+            (isAfter(end1, start2) && isBefore(end1, end2)) ||
+            (isAfter(end2, start1) && isBefore(end2, end1)));
+}

--- a/modules/validations/almost_junction.js
+++ b/modules/validations/almost_junction.js
@@ -8,7 +8,7 @@ import { actionAddMidpoint } from '../actions/add_midpoint';
 import { actionChangeTags } from '../actions/change_tags';
 import { actionMergeNodes } from '../actions/merge_nodes';
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel, utilDatesOverlap } from '../util';
 import { osmRoutableHighwayTagValues } from '../osm/tags';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { services } from '../services';
@@ -148,6 +148,12 @@ export function validationAlmostJunction(context) {
         }));
       }
 
+      // changing the date range is always an option
+      fixes.push(new validationIssueFix({
+        icon: 'iD-operation-change-date-range',
+        title: t.append('issues.fix.change_date_range.title')
+      }));
+
       return fixes;
     }
 
@@ -268,6 +274,11 @@ export function validationAlmostJunction(context) {
       const level1 = way.tags.level || '0',
         level2 = way2.tags.level || '0';
       if (level1 !== level2) return false;
+
+      // must have overlapping date ranges
+      if ((way.tags.start_date || way.tags.end_date) && (way2.tags.start_date || way2.tags.end_date)) {
+          if (!utilDatesOverlap(way.tags, way2.tags)) return false;
+      }
 
       return true;
     }

--- a/modules/validations/close_nodes.js
+++ b/modules/validations/close_nodes.js
@@ -1,5 +1,5 @@
 import { actionMergeNodes } from '../actions/merge_nodes';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel, utilDatesOverlap } from '../util';
 import { t } from '../core/localizer';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { osmPathHighwayTagValues } from '../osm/tags';
@@ -165,6 +165,11 @@ export function validationCloseNodes(context) {
                     }
                     if (zAxisDifferentiates) continue;
 
+                    // allow features to overlap spatially if they don't overlap temporally
+                    if ((node.tags.start_date || node.tags.end_date) && (nearby.tags.start_date || nearby.tags.end_date)) {
+                        if (!utilDatesOverlap(node.tags, nearby.tags)) continue;
+                    }
+
                     issues.push(new validationIssue({
                         type: type,
                         subtype: 'detached',
@@ -188,6 +193,10 @@ export function validationCloseNodes(context) {
                                 new validationIssueFix({
                                     icon: 'iD-icon-layers',
                                     title: t.append('issues.fix.use_different_layers_or_levels.title')
+                                }),
+                                new validationIssueFix({
+                                    icon: 'iD-operation-change-date-range',
+                                    title: t.append('issues.fix.change_date_range.title')
                                 })
                             ];
                         }

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -8,7 +8,7 @@ import { geoAngle, geoExtent, geoLatToMeters, geoLonToMeters, geoLineIntersectio
 import { osmNode } from '../osm/node';
 import { osmFlowingWaterwayTagValues, osmPathHighwayTagValues, osmRailwayTrackTagValues, osmRoutableHighwayTagValues } from '../osm/tags';
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel, utilDatesOverlap } from '../util';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 
@@ -73,7 +73,6 @@ export function validationCrossingWays(context) {
         return null;
     }
 
-
     function isLegitCrossing(tags1, featureType1, tags2, featureType2) {
 
         // assume 0 by default
@@ -114,6 +113,12 @@ export function validationCrossingWays(context) {
             // for building crossings, different layers are enough
             if (layer1 !== layer2) return true;
         }
+
+        // allow features to overlap spatially if they don't overlap temporally
+        if ((tags1.start_date || tags1.end_date) && (tags2.start_date || tags2.end_date)) {
+            if (!utilDatesOverlap(tags1, tags2)) return true;
+        }
+        
         return false;
     }
 

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -471,6 +471,12 @@ export function validationCrossingWays(context) {
                     }
                 }
 
+                // changing the date range is always an option
+                fixes.push(new validationIssueFix({
+                    icon: 'iD-operation-change-date-range',
+                    title: t.append('issues.fix.change_date_range.title')
+                }));
+
                 // repositioning the features is always an option
                 fixes.push(new validationIssueFix({
                     icon: 'iD-operation-move',

--- a/svg/iD-sprite/operations/operation-change-date-range.svg
+++ b/svg/iD-sprite/operations/operation-change-date-range.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   x="0"
+   y="0"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   id="svg136"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs140" />
+  <path
+     d="M10,1 L9,2 L9,3.062 C5.056,3.556 2,6.922 2,11 C2,15.418 5.582,19 10,19 C14.418,19 18,15.418 18,11 C18,8.533 16.881,6.341 15.125,4.875 L13.719,6.281 C15.114,7.38 16,9.086 16,11 C16,14.314 13.314,17 10,17 C6.686,17 4,14.314 4,11 C4,8.024 6.159,5.567 9,5.094 L9,6 L10,7 L13,4 L10,1 z"
+     fill="currentColor"
+     id="path132" />
+  <path
+     id="path4001"
+     style="stroke-width:0.681386"
+     d="M 8.5,9.5 V 16 h 1 l 1,-4.5 H 15 v -1 z" />
+</svg>

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -305,4 +305,25 @@ describe('iD.util', function() {
             expect(iD.utilOldestID(['z', 'a', 'A', 'Z'])).to.eql('z');
         });
     });
+
+    describe('utilDatesOverlap', function() {
+        it('compares years', function() {
+            expect(iD.utilDatesOverlap({start_date: '1970', end_date: '2000'},
+                                       {start_date: '1970', end_date: '2000'})).to.eql(true);
+            expect(iD.utilDatesOverlap({start_date: '1970', end_date: '2000'},
+                                       {start_date: '2000', end_date: '2038'})).to.eql(false);
+            expect(iD.utilDatesOverlap({start_date: '2000', end_date: '2038'},
+                                       {start_date: '1970', end_date: '2000'})).to.eql(false);
+            expect(iD.utilDatesOverlap({start_date: '1970', end_date: '2000'},
+                                       {start_date: '2000-01', end_date: '2038'})).to.eql(false);
+        });
+        it('compares full dates', function() {
+            expect(iD.utilDatesOverlap({start_date: '1970-01-01', end_date: '2000-01-01'},
+                                       {start_date: '1970-01-01', end_date: '2000-01-01'})).to.eql(true);
+            expect(iD.utilDatesOverlap({start_date: '1970-01-01', end_date: '2000-01-01'},
+                                       {start_date: '2000-01-01', end_date: '2038-01-01'})).to.eql(false);
+            expect(iD.utilDatesOverlap({start_date: '2000-01-01', end_date: '2038-01-01'},
+                                       {start_date: '1970-01-01', end_date: '2000-01-01'})).to.eql(false);
+        });
+    });
 });

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -197,6 +197,12 @@ describe('iD.validations.crossing_ways', function () {
         expect(issues).to.have.lengthOf(0);
     });
 
+    it('ignores buildings that overlap spatially but not temporally', function() {
+        createWaysWithOneCrossingPoint({ building: 'yes', end_date: '1970-01-01' }, { building: 'yes', start_date: '1970-01-01' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
     // warning crossing cases between ways
     it('flags road crossing road', function() {
         createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'residential' });
@@ -306,6 +312,11 @@ describe('iD.validations.crossing_ways', function () {
     it('flags railway bridge crossing road bridge on the same layer', function() {
         createWaysWithOneCrossingPoint({ highway: 'residential', bridge: 'yes' }, { railway: 'rail', bridge: 'yes' });
         verifySingleCrossingIssue(validate(), { railway: 'level_crossing' });
+    });
+
+    it('flags buildings that overlap spatially and temporally', function() {
+        createWaysWithOneCrossingPoint({ building: 'yes', start_date: '1970-01-01', end_date: '1971' }, { building: 'yes', start_date: '1970-01-01' });
+        verifySingleCrossingIssue(validate(), null);
     });
 
     it('flags railway crossing building', function() {


### PR DESCRIPTION
Avoid warning about crossing ways when the two ways’ date ranges don’t overlap or only touch. Mention the possibility of temporal separation in the validation rule’s message and suggestions.

<img src="https://user-images.githubusercontent.com/1231218/191552460-8f8ddcfb-a743-43bd-a771-990adf8aec8d.png" width="800" alt="warning">

Fixes OpenHistoricalMap/issues#288.