### PR TITLE
Reimplement date field validator as validation rule

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1817,6 +1817,10 @@ en:
         message: '{feature} has an invalid email address'
         message_multi: '{feature} has multiple invalid email addresses'
         reference: 'Email addresses must look like "user@example.com".'
+      date:
+        message_start: '{feature} has an invalid start date'
+        message_end: '{feature} has an invalid end date'
+        reference: 'A date must be formatted as YYYY-MM-DD, YYYY-MM, or YYYY.'
     line_as_area:
       message: '{feature} should be a line, not an area'
     line_as_point:
@@ -1951,6 +1955,9 @@ en:
       move_tags:
         title: Move the tags
         annotation: Moved tags.
+      reformat_date:
+        title: Tag as {date}
+        annotation: Tagged a date with the correct format.
       remove_from_relation:
         title: Remove from relation
       remove_generic_name:

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -33,6 +33,7 @@ export { utilGetSetValue } from './get_set_value';
 export { utilHashcode } from './util';
 export { utilHighlightEntities } from './util';
 export { utilKeybinding } from './keybinding';
+export { utilNormalizeDateString } from './util';
 export { utilNoAuto } from './util';
 export { utilObjectOmit } from './object';
 export { utilCompareIDs } from './util';

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -305,4 +305,39 @@ describe('iD.util', function() {
             expect(iD.utilOldestID(['z', 'a', 'A', 'Z'])).to.eql('z');
         });
     });
+
+    describe('utilNormalizeDateString', function() {
+        it('pads dates', function() {
+            expect(iD.utilNormalizeDateString('1970-01-01').value).to.eql('1970-01-01');
+            expect(iD.utilNormalizeDateString('1970-01-1').value).to.eql('1970-01-01');
+            expect(iD.utilNormalizeDateString('1970-1-01').value).to.eql('1970-01-01');
+            expect(iD.utilNormalizeDateString('-1-1-01').value).to.eql('-0001-01-01');
+            expect(iD.utilNormalizeDateString('123').value).to.eql('0123');
+            expect(iD.utilNormalizeDateString('-4003').value).to.eql('-4003'); // beyond displayable year range but still valid
+            expect(iD.utilNormalizeDateString('31337').value).to.eql('31337');
+            expect(iD.utilNormalizeDateString('-31337').value).to.eql('-31337');
+        });
+        it('wraps dates', function() {
+            expect(iD.utilNormalizeDateString('1970-01-00').value).to.eql('1969-12-31');
+            expect(iD.utilNormalizeDateString('1970-12-32').value).to.eql('1971-01-01');
+            expect(iD.utilNormalizeDateString('1970-02-29').value).to.eql('1970-03-01');
+            expect(iD.utilNormalizeDateString('1970-00').value).to.eql('1969-12');
+            expect(iD.utilNormalizeDateString('1970-23').value).to.eql('1971-11'); // no EDTF for now
+        });
+        it('rejects malformed dates', function() {
+            expect(iD.utilNormalizeDateString('1970-01--1')).to.eql(null);
+            expect(iD.utilNormalizeDateString('197X')).to.eql(null); // no EDTF for now
+        });
+        it('respects the original precision', function() {
+            expect(iD.utilNormalizeDateString('123').value).to.eql('0123');
+            expect(iD.utilNormalizeDateString('2000-06').value).to.eql('2000-06');
+            expect(iD.utilNormalizeDateString('2000-06').localeOptions.month).to.eql('long');
+            expect(iD.utilNormalizeDateString('2000-06').localeOptions.day).to.eql(undefined);
+        });
+        it('displays era before common era', function() {
+            expect(iD.utilNormalizeDateString('1').localeOptions.era).to.eql(undefined);
+            expect(iD.utilNormalizeDateString('0').localeOptions.era).to.eql('short');
+            expect(iD.utilNormalizeDateString('-1').localeOptions.era).to.eql('short');
+        });
+    });
 });


### PR DESCRIPTION
Replaced the date format validator from #81 with a user-friendlier check within the existing invalid format validation rule. The new rule comes with a one-click option to reformat a malformed but understandable date, wrapping around months and years as necessary, as well as an option to remove the malformed date.

<img src="https://user-images.githubusercontent.com/1231218/191653854-b2e67068-4e64-405c-bc07-ca66de25b6f7.png" width="379" alt="-00004003-9-53" align="top"> <img src="https://user-images.githubusercontent.com/1231218/191653929-8d424bb1-1054-4811-80fd-4c4586af2512.png" width="379" alt="July 4, 1776" align="top"> <img src="https://user-images.githubusercontent.com/1231218/191653992-676c3d9f-2097-4347-b65a-742b90da8f82.png" width="379" alt="1970-1/2038-1" align="top"> <img src="https://user-images.githubusercontent.com/1231218/191655600-d72ed4dc-5492-4c16-b83a-61aaab7f4b77.png" width="379" alt="2022-23" align="top">

Fixes OpenHistoricalMap/issues#445.