### PR TITLE
Add important OpenHistoricalMap fields to every preset

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2446,3 +2446,13 @@ en:
     identifier: "Identifier"
     label: "Label"
     description: "Description"
+  custom_presets:
+    fields:
+      end_date:
+        label: End Date
+        placeholder: YYYY-MM-DD
+        terms: abandoned, destruction, destroyed, demolition, demolished, closed, closure
+      license:
+        label: License
+        placeholder: CC0
+        terms: copyleft, copyright

--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -343,6 +343,8 @@ export function coreLocalizer() {
         return !!localizer.tInfo(stringId, { default: 'nothing found'}).locale;
     };
 
+    localizer.coalesceStringIds = stringIds => stringIds.find(id => localizer.hasTextForStringId(id)) || stringIds[stringIds.length - 1];
+
     // Returns only the localized text, discarding the locale info
     localizer.t = function(stringId, replacements, locale) {
         return localizer.tInfo(stringId, replacements, locale).text;

--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -20,10 +20,14 @@ export function presetField(fieldID, field) {
     return !_this.geometry || geometries.every(geom => _this.geometry.indexOf(geom) !== -1);
   };
 
-  _this.t = (scope, options) => t(`_tagging.presets.fields.${fieldID}.${scope}`, options);
-  _this.t.html = (scope, options) => t.html(`_tagging.presets.fields.${fieldID}.${scope}`, options);
-  _this.t.append = (scope, options) => t.append(`_tagging.presets.fields.${fieldID}.${scope}`, options);
-  _this.hasTextForStringId = (scope) => localizer.hasTextForStringId(`_tagging.presets.fields.${fieldID}.${scope}`);
+  _this.t = (scope, options) => t(localizer.coalesceStringIds([`custom_presets.fields.${fieldID}.${scope}`,
+                                                               `_tagging.presets.fields.${fieldID}.${scope}`]), options);
+  _this.t.html = (scope, options) => t.html(localizer.coalesceStringIds([`custom_presets.fields.${fieldID}.${scope}`,
+                                                                         `_tagging.presets.fields.${fieldID}.${scope}`]), options);
+  _this.t.append = (scope, options) => t.append(localizer.coalesceStringIds([`custom_presets.fields.${fieldID}.${scope}`,
+                                                                             `_tagging.presets.fields.${fieldID}.${scope}`]), options);
+  _this.hasTextForStringId = (scope) => localizer.hasTextForStringId(`custom_presets.fields.${fieldID}.${scope}`) ||
+    localizer.hasTextForStringId(`_tagging.presets.fields.${fieldID}.${scope}`);
 
   _this.title = () => _this.overrideLabel || _this.t('label', { 'default': fieldID });
   _this.label = () => _this.overrideLabel ?

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -72,6 +72,24 @@ export function presetIndex() {
           presets: vals[2],
           fields: vals[3]
         });
+
+        // Add OpenHistoricalMap-specific fields.
+        _this.merge({
+          fields: {
+            end_date: {
+              ...vals[3].start_date,
+              key: 'end_date'
+            },
+            license: {
+              key: 'license',
+              type: 'combo',
+              universal: true,
+              snake_case: false,
+              caseSensitive: true
+            }
+          }
+        });
+
         osmSetAreaKeys(_this.areaKeys());
         osmSetPointTags(_this.pointTags());
         osmSetVertexTags(_this.vertexTags());

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -19,6 +19,27 @@ export { presetPreset };
 let _mainPresetIndex = presetIndex(); // singleton
 export { _mainPresetIndex as presetManager };
 
+/**
+ * Adds fields specific to OpenHistoricalMap.
+ */
+function addHistoricalFields(fields) {
+  fields.end_date = {
+    ...fields.start_date,
+    key: 'end_date'
+  };
+
+  // A combo box would encourage mappers to choose one of the suggestions, but we want mappers to be as detailed as possible.
+  fields.source.type = 'text';
+
+  fields.license = {
+    key: 'license',
+    type: 'combo',
+    universal: true,
+    snake_case: false,
+    caseSensitive: true
+  };
+}
+
 //
 // `presetIndex` wraps a `presetCollection`
 // with methods for loading new data and returning defaults
@@ -66,28 +87,12 @@ export function presetIndex() {
         fileFetcher.get('preset_fields')
       ])
       .then(vals => {
+        addHistoricalFields(vals[3]);
         _this.merge({
           categories: vals[0],
           defaults: vals[1],
           presets: vals[2],
           fields: vals[3]
-        });
-
-        // Add OpenHistoricalMap-specific fields.
-        _this.merge({
-          fields: {
-            end_date: {
-              ...vals[3].start_date,
-              key: 'end_date'
-            },
-            license: {
-              key: 'license',
-              type: 'combo',
-              universal: true,
-              snake_case: false,
-              caseSensitive: true
-            }
-          }
         });
 
         osmSetAreaKeys(_this.areaKeys());

--- a/modules/ui/sections/preset_fields.js
+++ b/modules/ui/sections/preset_fields.js
@@ -64,8 +64,17 @@ export function uiSectionPresetFields(context) {
 
             _fieldsArr = [];
 
+            // Ideally, everything in OpenHistoricalMap is dated and sourced.
+            let coreKeys = ['start_date', 'end_date', 'source'];
+            coreKeys.forEach(key => {
+                let field = presetsManager.field(key);
+                if (field) {
+                    _fieldsArr.push(uiField(context, field, _entityIDs));
+                }
+            });
+
             sharedFields.forEach(function(field) {
-                if (field.matchAllGeometry(geometries)) {
+                if (!coreKeys.includes(field.id) && field.matchAllGeometry(geometries)) {
                     _fieldsArr.push(
                         uiField(context, field, _entityIDs)
                     );
@@ -86,6 +95,7 @@ export function uiSectionPresetFields(context) {
 
             additionalFields.forEach(function(field) {
                 if (sharedFields.indexOf(field) === -1 &&
+                    !coreKeys.includes(field.id) &&
                     field.matchAllGeometry(geometries)) {
                     _fieldsArr.push(
                         uiField(context, field, _entityIDs, { show: false })


### PR DESCRIPTION
This PR adds the all-important Start Date, End Date, and Source(s) fields to the inspector regardless of the selected features’ presets. It also adds License as an optional field.

This implementation respects preset inheritance, which was introduced upstream after the previous implementation of these fields landed in https://github.com/OpenHistoricalMap/iD/commit/12588352df2e3b3f990225a7bc3545f9309f545f. A preset that doesn’t define its own fields inherits the same fields it would inherit in OSM’s iD, but the core OHM fields are included too. OHM’s custom fields will be localized using the same mechanism as the rest of the core interface; however, this PR does not include any translations.

Here’s what the Law Office preset looks like initially:

<img src="https://user-images.githubusercontent.com/1231218/196049639-e5ea96ed-c1d1-47cb-82c2-ff1e1b1aebbc.png" width="379" alt="lawyer">

If the user selects a feature that’s already tagged with `license` or they select License from the “Add field” menu, the License field appears:

<img src="https://user-images.githubusercontent.com/1231218/195967259-5b1542f3-1266-4dcc-bf57-da7426eadc56.png" width="379" alt="license">

Fixes OpenHistoricalMap/issues#449. Working towards OpenHistoricalMap/issues#395.

<details>
<summary>Old screenshots</summary>
<img src="https://user-images.githubusercontent.com/1231218/195967223-e7d0e823-d003-4da0-abb1-e2fe43a6293a.png" width="379" alt="lawyer">
</details>