### PR TITLE
Remove links to not-yet-forked tools from History panel

### DIFF
--- a/modules/ui/panels/history.js
+++ b/modules/ui/panels/history.js
@@ -42,14 +42,6 @@ export function uiPanelHistory(context) {
                 .attr('target', '_blank')
                 .call(t.append('info_panels.history.profile_link'));
         }
-
-        links
-            .append('a')
-            .attr('class', 'user-hdyc-link')
-            .attr('href', 'https://hdyc.neis-one.org/?' + userName)
-            .attr('target', '_blank')
-            .attr('tabindex', -1)
-            .text('HDYC');
     }
 
 
@@ -78,20 +70,6 @@ export function uiPanelHistory(context) {
                 .attr('target', '_blank')
                 .call(t.append('info_panels.history.changeset_link'));
         }
-
-        links
-            .append('a')
-            .attr('class', 'changeset-osmcha-link')
-            .attr('href', 'https://osmcha.org/changesets/' + changeset)
-            .attr('target', '_blank')
-            .text('OSMCha');
-
-        links
-            .append('a')
-            .attr('class', 'changeset-achavi-link')
-            .attr('href', 'https://overpass-api.de/achavi/?changeset=' + changeset)
-            .attr('target', '_blank')
-            .text('Achavi');
     }
 
 
@@ -199,13 +177,6 @@ export function uiPanelHistory(context) {
                 .attr('target', '_blank')
                 .call(t.append('info_panels.history.history_link'));
         }
-        links
-            .append('a')
-            .attr('class', 'pewu-history-viewer-link')
-            .attr('href', 'https://pewu.github.io/osm-history/#/' + entity.type + '/' + entity.osmId())
-            .attr('target', '_blank')
-            .attr('tabindex', -1)
-            .text('PeWu');
 
         var list = selection
             .append('ul');


### PR DESCRIPTION
Removed the links to Achavi, How Did You Contribute?, Pewu, and OSMCha from the History panel. None of these projects have been forked for OpenHistoricalMap, and HYDC isn’t even forkable. OpenHistoricalMap/issues#306 and OpenHistoricalMap/issues#390 track standing up statistical and visualization tools for OHM, but in the meantime, it would be misleading to link to these tools with user IDs that may be incorrect and changeset IDs that are guaranteed to be incorrect.

<img src="https://user-images.githubusercontent.com/1231218/195968028-b5c8810b-4cdd-45bd-9ca4-1833ae310252.png" width="250" alt="history">