### PR TITLE
Map Data, Date Range - fix inputs being repeatedly created

### DIFF
--- a/modules/ui/sections/index.js
+++ b/modules/ui/sections/index.js
@@ -6,6 +6,7 @@ export { uiSectionDataLayers } from './data_layers';
 export { uiSectionEntityIssues } from './entity_issues';
 export { uiSectionFeatureType } from './feature_type';
 export { uiSectionMapFeatures } from './map_features';
+export { uiSectionDateRange } from './map_daterange';
 export { uiSectionMapStyleOptions } from './map_style_options';
 export { uiSectionOverlayList } from './overlay_list';
 export { uiSectionPhotoOverlays } from './photo_overlays';

--- a/modules/ui/sections/map_daterange.js
+++ b/modules/ui/sections/map_daterange.js
@@ -29,6 +29,11 @@ export function uiSectionDateRange(context) {
     function renderDisclosureContent(selection) {
         const container = selection.selectAll('.date_ranges-container').data([0]);
 
+        // for some reason this one uiSection keeps adding content every time it's expanded,
+        // so there are 2 inputs, then 4, then 6, ...
+        const alreadyhasinputs = container.enter().selectAll('input').size();
+        if (alreadyhasinputs) return;
+
         // start date label & input
         const mindate_label = container.enter()
             .append('label')


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/518

When the Map Data panel's Date Range section is toggled, the labels & inputs were being created on every iteration of toggling the panel. This works around that by checking that the inputs don't already exist.