### PR TITLE
Add chronology relation preset

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2458,3 +2458,7 @@ en:
         label: License
         placeholder: CC0
         terms: copyleft, copyright
+    presets:
+      type/chronology:
+        name: Chronology
+        terms: history, timeline, movement, evolution, change

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -20,6 +20,21 @@ let _mainPresetIndex = presetIndex(); // singleton
 export { _mainPresetIndex as presetManager };
 
 /**
+ * Adds presets specific to OpenHistoricalMap.
+ */
+function addHistoricalPresets(presets) {
+  // https://wiki.openstreetmap.org/wiki/Open_Historical_Map/Tags/Relation/chronology
+  presets['type/chronology'] = {
+    icon: 'temaki-clock',
+    fields: ['name'],
+    geometry: ['relation'],
+    tags: {
+      type: 'chronology'
+    }
+  };
+}
+
+/**
  * Adds fields specific to OpenHistoricalMap.
  */
 function addHistoricalFields(fields) {
@@ -87,6 +102,7 @@ export function presetIndex() {
         fileFetcher.get('preset_fields')
       ])
       .then(vals => {
+        addHistoricalPresets(vals[2]);
         addHistoricalFields(vals[3]);
         _this.merge({
           categories: vals[0],

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -20,6 +20,13 @@ let _mainPresetIndex = presetIndex(); // singleton
 export { _mainPresetIndex as presetManager };
 
 /**
+ * Sets preset defaults specific to OpenHistoricalMap.
+ */
+function setHistoricalDefaults(defaults) {
+  defaults.relation.unshift('type/chronology');
+}
+
+/**
  * Adds presets specific to OpenHistoricalMap.
  */
 function addHistoricalPresets(presets) {
@@ -102,6 +109,7 @@ export function presetIndex() {
         fileFetcher.get('preset_fields')
       ])
       .then(vals => {
+        setHistoricalDefaults(vals[1]);
         addHistoricalPresets(vals[2]);
         addHistoricalFields(vals[3]);
         _this.merge({

--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -1,4 +1,4 @@
-import { t } from '../core/localizer';
+import { localizer, t } from '../core/localizer';
 import { osmAreaKeys, osmAreaKeysExceptions } from '../osm/tags';
 import { utilArrayUniq, utilObjectOmit } from '../util';
 import { utilSafeClassName } from '../util/util';
@@ -92,12 +92,14 @@ export function presetPreset(presetID, preset, addable, allFields, allPresets) {
 
 
   _this.t = (scope, options) => {
-    const textID = `_tagging.presets.presets.${presetID}.${scope}`;
+    const textID = localizer.coalesceStringIds([`custom_presets.presets.${presetID}.${scope}`,
+                                                `_tagging.presets.presets.${presetID}.${scope}`]);
     return t(textID, options);
   };
 
   _this.t.append = (scope, options) => {
-    const textID = `_tagging.presets.presets.${presetID}.${scope}`;
+    const textID = localizer.coalesceStringIds([`custom_presets.presets.${presetID}.${scope}`,
+                                                `_tagging.presets.presets.${presetID}.${scope}`]);
     return t.append(textID, options);
   };
 
@@ -127,7 +129,8 @@ export function presetPreset(presetID, preset, addable, allFields, allPresets) {
       if (_this.suggestion) {
         let path = presetID.split('/');
         path.pop();  // remove brand name
-        return t('_tagging.presets.presets.' + path.join('/') + '.name');
+        return t(localizer.coalesceStringIds([`custom_presets.presets.${path.join('/')}.name`,
+                                              `_tagging.presets.presets.${path.join('/')}.name`]));
       }
       return null;
   };
@@ -136,7 +139,8 @@ export function presetPreset(presetID, preset, addable, allFields, allPresets) {
       if (_this.suggestion) {
         let path = presetID.split('/');
         path.pop();  // remove brand name
-        return t.append('_tagging.presets.presets.' + path.join('/') + '.name');
+        return t.append(`custom_presets.presets.${path.join('/')}.name`,
+                        `_tagging.presets.presets.${path.join('/')}.name`);
       }
       return null;
   };

--- a/modules/services/osm_wikibase.js
+++ b/modules/services/osm_wikibase.js
@@ -97,9 +97,15 @@ export default {
     },
 
 
-    toSitelink: function(key, value) {
-        var result = value ? ('Tag:' + key + '=' + value) : 'Key:' + key;
-        return result.replace(/_/g, ' ').trim();
+    toSitelink: function(key, value, isHistorical) {
+        var type = value ? 'Tag' : 'Key';
+        var prefix = '';
+        if (isHistorical) {
+            prefix = `Open Historical Map/Tags/${type}/`;
+        } else {
+            prefix = type + ':';
+        }
+        return prefix + (value ? `${key}=${value}` : key).replace(/_/g, ' ').trim();
     },
 
 
@@ -117,8 +123,11 @@ export default {
         var titles = [];
         var result = {};
         var rtypeSitelink = (params.key === 'type' && params.value) ? ('Relation:' + params.value).replace(/_/g, ' ').trim() : false;
+        var rtypeSitelinkHistorical = (params.key === 'type' && params.value) ? ('Open Historical Map/Tags/Relation/' + params.value.replace(/_/g, ' ').trim()) : false;
         var keySitelink = params.key ? this.toSitelink(params.key) : false;
+        var keySitelinkHistorical = params.key ? this.toSitelink(params.key, null, true) : false;
         var tagSitelink = (params.key && params.value) ? this.toSitelink(params.key, params.value) : false;
+        var tagSitelinkHistorical = (params.key && params.value) ? this.toSitelink(params.key, params.value, true) : false;
         var localeSitelink;
 
         if (params.langCodes) {
@@ -134,26 +143,32 @@ export default {
         }
 
         if (rtypeSitelink) {
-            if (_wikibaseCache[rtypeSitelink]) {
+            if (_wikibaseCache[rtypeSitelinkHistorical]) {
+                result.rtype = _wikibaseCache[rtypeSitelinkHistorical];
+            } else if (_wikibaseCache[rtypeSitelink]) {
                 result.rtype = _wikibaseCache[rtypeSitelink];
             } else {
-                titles.push(rtypeSitelink);
+                titles.push(rtypeSitelinkHistorical, rtypeSitelink);
             }
         }
 
         if (keySitelink) {
-            if (_wikibaseCache[keySitelink]) {
+            if (_wikibaseCache[keySitelinkHistorical]) {
+                result.key = _wikibaseCache[keySitelinkHistorical];
+            } else if (_wikibaseCache[keySitelink]) {
                 result.key = _wikibaseCache[keySitelink];
             } else {
-                titles.push(keySitelink);
+                titles.push(keySitelinkHistorical, keySitelink);
             }
         }
 
         if (tagSitelink) {
-            if (_wikibaseCache[tagSitelink]) {
+            if (_wikibaseCache[tagSitelinkHistorical]) {
+                result.tag = _wikibaseCache[tagSitelinkHistorical];
+            } else if (_wikibaseCache[tagSitelink]) {
                 result.tag = _wikibaseCache[tagSitelink];
             } else {
-                titles.push(tagSitelink);
+                titles.push(tagSitelinkHistorical, tagSitelink);
             }
         }
 
@@ -195,11 +210,20 @@ export default {
                         if (title === rtypeSitelink) {
                             _wikibaseCache[rtypeSitelink] = res;
                             result.rtype = res;
+                        } else if (title === rtypeSitelinkHistorical) {
+                            _wikibaseCache[rtypeSitelinkHistorical] = res;
+                            result.rtype = res;
                         } else if (title === keySitelink) {
                             _wikibaseCache[keySitelink] = res;
                             result.key = res;
+                        } else if (title === keySitelinkHistorical) {
+                            _wikibaseCache[keySitelinkHistorical] = res;
+                            result.key = res;
                         } else if (title === tagSitelink) {
                             _wikibaseCache[tagSitelink] = res;
+                            result.tag = res;
+                        } else if (title === tagSitelinkHistorical) {
+                            _wikibaseCache[tagSitelinkHistorical] = res;
                             result.tag = res;
                         } else if (title === localeSitelink) {
                             localeID = res.id;

--- a/modules/services/osm_wikibase.js
+++ b/modules/services/osm_wikibase.js
@@ -148,7 +148,7 @@ export default {
             } else if (_wikibaseCache[rtypeSitelink]) {
                 result.rtype = _wikibaseCache[rtypeSitelink];
             } else {
-                titles.push(rtypeSitelinkHistorical, rtypeSitelink);
+                titles.push(rtypeSitelink, rtypeSitelinkHistorical);
             }
         }
 
@@ -158,7 +158,7 @@ export default {
             } else if (_wikibaseCache[keySitelink]) {
                 result.key = _wikibaseCache[keySitelink];
             } else {
-                titles.push(keySitelinkHistorical, keySitelink);
+                titles.push(keySitelink, keySitelinkHistorical);
             }
         }
 
@@ -168,7 +168,7 @@ export default {
             } else if (_wikibaseCache[tagSitelink]) {
                 result.tag = _wikibaseCache[tagSitelink];
             } else {
-                titles.push(tagSitelinkHistorical, tagSitelink);
+                titles.push(tagSitelink, tagSitelinkHistorical);
             }
         }
 
@@ -207,23 +207,23 @@ export default {
                     if (res.missing !== '') {
 
                         var title = res.sitelinks.wiki.title;
-                        if (title === rtypeSitelink) {
-                            _wikibaseCache[rtypeSitelink] = res;
-                            result.rtype = res;
-                        } else if (title === rtypeSitelinkHistorical) {
+                        if (title === rtypeSitelinkHistorical) {
                             _wikibaseCache[rtypeSitelinkHistorical] = res;
                             result.rtype = res;
-                        } else if (title === keySitelink) {
-                            _wikibaseCache[keySitelink] = res;
-                            result.key = res;
+                        } else if (title === rtypeSitelink) {
+                            _wikibaseCache[rtypeSitelink] = res;
+                            result.rtype = res;
                         } else if (title === keySitelinkHistorical) {
                             _wikibaseCache[keySitelinkHistorical] = res;
                             result.key = res;
-                        } else if (title === tagSitelink) {
-                            _wikibaseCache[tagSitelink] = res;
-                            result.tag = res;
+                        } else if (title === keySitelink) {
+                            _wikibaseCache[keySitelink] = res;
+                            result.key = res;
                         } else if (title === tagSitelinkHistorical) {
                             _wikibaseCache[tagSitelinkHistorical] = res;
+                            result.tag = res;
+                        } else if (title === tagSitelink) {
+                            _wikibaseCache[tagSitelink] = res;
                             result.tag = res;
                         } else if (title === localeSitelink) {
                             localeID = res.id;


### PR DESCRIPTION
Added a Chronology preset for `chronology` relations. As in #145, this comes with a mechanism for extending the standard set of presets and default presets that come with id-tagging-schema.

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/6f8f0d1f-6227-4800-86bc-1bc0524b7de1" width="399" alt="Default relation types">

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/1613b1d5-0f26-4ddb-b89f-9bc3c723d083" width="399" alt="Chronology relation inspector">

I’ve also tweaked the ℹ️ button to look for documentation from OpenHistoricalMap-related data items on the OSM Wiki, not just OSM-related data items. The data item must have a sitelink to an article titled “Open Historical Map/Tags/Key/<var>key</var>” for keys, “Open Historical Map/Tags/Relation/Tag/<var>key</var>=<var>value</var>” for tag values, or “Open Historical Map/Tags/Relation/<var>type</var>” for relation types.

Fixes OpenHistoricalMap/issues#540.