### PR TITLE
Fix subtitles of inheriting presets

### DIFF
--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -139,8 +139,8 @@ export function presetPreset(presetID, preset, addable, allFields, allPresets) {
       if (_this.suggestion) {
         let path = presetID.split('/');
         path.pop();  // remove brand name
-        return t.append(`custom_presets.presets.${path.join('/')}.name`,
-                        `_tagging.presets.presets.${path.join('/')}.name`);
+        return t.append(localizer.coalesceStringIds([`custom_presets.presets.${path.join('/')}.name`,
+                                                     `_tagging.presets.presets.${path.join('/')}.name`]));
       }
       return null;
   };


### PR DESCRIPTION
#178 incorrectly passed the fallback string key ID as a second parameter instead of nesting a call to `localizer.coalesceStringIds()` when computing these subtitles. The second parameter of `localizer.t.append()` is interpreted as an object containing substitutions. NSI-generated presets contain `{token}` placeholder syntax as their subtitles because each preset inherits the title from an id-tagging-schema preset. This change fixes the code to be consistent with the code just above it in `preset.subtitle()`.

Fixes OpenHistoricalMap/issues#580.