### PR TITLE
Add Esri World Imagery Wayback to background layers

### DIFF
--- a/modules/core/file_fetcher.js
+++ b/modules/core/file_fetcher.js
@@ -39,6 +39,7 @@ export function coreFileFetcher() {
     'preset_defaults': presetsCdnUrl + 'dist/preset_defaults.min.json',
     'preset_fields': presetsCdnUrl + 'dist/fields.min.json',
     'preset_presets': presetsCdnUrl + 'dist/presets.min.json',
+    'wayback': 'https://www.arcgis.com/sharing/rest/content/groups/0f3189e1d1414edfad860b697b7d8311?f=json',
     'wmf_sitematrix': wmfSitematrixCdnUrl.replace('{version}', '0.1') + 'wikipedia.min.json'
   };
 

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -37,6 +37,7 @@ export function rendererBackground(context) {
         // Extracts the layer's date from the title.
         let extractDateFromTitle = title => {
           const dateComponents = title.match(/\(Wayback (\d{4})-(\d\d)-(\d\d)\)/);
+          if (!dateComponents) return;
           return new Date(Date.UTC(parseInt(dateComponents[1], 10),
                                    parseInt(dateComponents[2], 10) - 1,
                                    parseInt(dateComponents[3], 10)));
@@ -48,7 +49,7 @@ export function rendererBackground(context) {
             .filter(item => item.type === 'Map Service')
             .map(item => {
               // Extract the layer's date from the title to avoid having to hit each MapServer right away.
-              const date = extractDateFromTitle(item.title);
+              const date = extractDateFromTitle(item.title) || new Date(item.created);
               const dateString = date.toISOString().split('T')[0];
               return [dateString, item.url];
             }));
@@ -56,8 +57,8 @@ export function rendererBackground(context) {
           _waybackIndex = groups.items
             .filter(item => item.type === 'WMTS')
             .map(item => {
-              const date = extractDateFromTitle(item.title);
-              const dateString = date.toISOString().split('T')[0];
+              const date = extractDateFromTitle(item.title) || new Date(item.created);
+              const dateString = date && date.toISOString().split('T')[0];
 
               // Convert the bounding box to a polygon.
               const bbox = {

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -16,6 +16,7 @@ import { utilRebind } from '../util/rebind';
 
 
 let _imageryIndex = null;
+let _waybackIndex = null;
 
 export function rendererBackground(context) {
   const dispatch = d3_dispatch('change');
@@ -30,9 +31,81 @@ export function rendererBackground(context) {
 
 
   function ensureImageryIndex() {
-    return fileFetcher.get('imagery')
+    return fileFetcher.get('wayback')
+      .then(groups => {
+        // TODO: Follow pagination via nextStart property.
+        // Extracts the layer's date from the title.
+        let extractDateFromTitle = title => {
+          const dateComponents = title.match(/\(Wayback (\d{4})-(\d\d)-(\d\d)\)/);
+          return new Date(Date.UTC(parseInt(dateComponents[1], 10),
+                                   parseInt(dateComponents[2], 10) - 1,
+                                   parseInt(dateComponents[3], 10)));
+        };
+
+        if (!_waybackIndex) {
+          // Index the metadata MapServer URLs by the date of the World Imagery map.
+          let metadataMapServersByDate = Object.fromEntries(groups.items
+            .filter(item => item.type === 'Map Service')
+            .map(item => {
+              // Extract the layer's date from the title to avoid having to hit each MapServer right away.
+              const date = extractDateFromTitle(item.title);
+              const dateString = date.toISOString().split('T')[0];
+              return [dateString, item.url];
+            }));
+
+          _waybackIndex = groups.items
+            .filter(item => item.type === 'WMTS')
+            .map(item => {
+              const date = extractDateFromTitle(item.title);
+              const dateString = date.toISOString().split('T')[0];
+
+              // Convert the bounding box to a polygon.
+              const bbox = {
+                min_lon: item.extent[0][0],
+                min_lat: item.extent[0][1],
+                max_lon: item.extent[1][0],
+                max_lat: item.extent[1][1],
+              };
+              const polygon = [[
+                [bbox.min_lon, bbox.min_lat],
+                [bbox.min_lon, bbox.max_lat],
+                [bbox.max_lon, bbox.max_lat],
+                [bbox.max_lon, bbox.min_lat],
+                [bbox.min_lon, bbox.min_lat],
+              ]];
+
+              // Convert placeholder tokens in the URL template from Esri's format to OSM's.
+              const template = item.url
+                .replaceAll('{level}', '{zoom}')
+                .replaceAll('{row}', '{y}')
+                .replaceAll('{col}', '{x}');
+
+              return {
+                id: 'EsriWorldImagery_' + dateString,
+                name: item.title,
+                type: 'tms',
+                template: template,
+                metadata: metadataMapServersByDate[dateString],
+                startDate: date.toISOString(),
+                endDate: date.toISOString(),
+                polygon: polygon,
+                terms_text: item.accessInformation,
+                description: item.snippet,
+                // Match Esri World Imagery layer
+                'default': true,
+                zoomExtent: [0, 22],
+                terms_url: 'https://wiki.openstreetmap.org/wiki/Esri',
+                icon: 'https://osmlab.github.io/editor-layer-index/sources/world/EsriImageryClarity.png',
+              };
+            });
+        }
+        return fileFetcher.get('imagery');
+      })
       .then(sources => {
         if (_imageryIndex) return _imageryIndex;
+
+        // Append Esri World Imagery Wayback sources.
+        sources.push(..._waybackIndex);
 
         _imageryIndex = {
           imagery: sources,

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -102,11 +102,16 @@ export function rendererBackground(context) {
         }
         return fileFetcher.get('imagery');
       })
+      .catch(() => {
+        return fileFetcher.get('imagery');
+      })
       .then(sources => {
         if (_imageryIndex) return _imageryIndex;
 
         // Append Esri World Imagery Wayback sources.
-        sources.push(..._waybackIndex);
+        if (_waybackIndex) {
+          sources.push(..._waybackIndex);
+        }
 
         _imageryIndex = {
           imagery: sources,

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -452,7 +452,11 @@ rendererBackgroundSource.Esri = function(data) {
 
 
     esri.getMetadata = function(center, tileCoord, callback) {
-        if (esri.id !== 'EsriWorldImagery') {
+        let mapServerUrl = esri.metadata;
+        if (esri.id === 'EsriWorldImagery') {
+            mapServerUrl = 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer';
+        }
+        if (!mapServerUrl) {
             // rest endpoint is not available for ESRI's "clarity" imagery
             return callback(null, {});
         }
@@ -466,7 +470,7 @@ rendererBackgroundSource.Esri = function(data) {
         if (inflight[tileID]) return;
 
         // build up query using the layer appropriate to the current zoom
-        var url = 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/4/query';
+        var url = mapServerUrl + '/4/query';
         url += '?returnGeometry=false&geometry=' + centerPoint + '&inSR=4326&geometryType=esriGeometryPoint&outFields=*&f=json';
 
         if (!cache[tileID]) {


### PR DESCRIPTION
Injected a source for each of the layers in the Esri World Imagery Wayback feed. The code to query Esri’s metadata layer now respects the metadata item corresponding to the layer in the feed. This PR does not include any UI changes, so the feed’s layers are flooding the Background list. I think this is a small price to pay for getting access to such useful imagery, but we should figure out a more usable UI soon that doesn’t bury other sources that the user might need to discover.

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/6dcf6677-ebeb-45e6-acae-3beefd84da09" width="1440" alt="World Imagery (Wayback 2018-04-25) depicting Apple Park under construction">

Fixes OpenHistoricalMap/issues#582.