### PR TITLE
Fix errors populating invalid date error messages

### DIFF
--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -15,7 +15,7 @@ export function validationFormatting() {
                 .enter()
                 .append('div')
                 .attr('class', 'issue-reference')
-                .text(t.append('issues.invalid_format.date.reference'));
+                .call(t.append('issues.invalid_format.date.reference'));
         }
 
         function validateDate(key, msgKey) {
@@ -47,7 +47,7 @@ export function validationFormatting() {
                                     var newTags = Object.assign({}, entityInGraph.tags);
                                     newTags[key] = normalized.value;
                                     return actionChangeTags(entityInGraph.id, newTags)(graph);
-                                }, t.append('issues.fix.reformat_date.annotation'));
+                                }, t('issues.fix.reformat_date.annotation'));
                             }
                         }));
                     }
@@ -61,7 +61,7 @@ export function validationFormatting() {
                                 var newTags = Object.assign({}, entityInGraph.tags);
                                 delete newTags[key];
                                 return actionChangeTags(entityInGraph.id, newTags)(graph);
-                            }, t.append('issues.fix.remove_tag.annotation'));
+                            }, t('issues.fix.remove_tag.annotation'));
                         }
                     }));
                     return fixes;


### PR DESCRIPTION
Fixed a JavaScript error that prevented the full error message for invalid dates from appearing, and also one that prevented the suggested fix from being applied.

Before and after:

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/e610fca9-8704-4728-b268-3d8863eabf53" width="399" alt="Before" align="top">
<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/306d9284-130d-4612-b70d-953d023383b3" width="379" alt="After" align="top">

Fixes OpenHistoricalMap/issues#567.