### PR TITLE
Replace OSM global community resources with OHM analogues

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2462,3 +2462,9 @@ en:
       type/chronology:
         name: Chronology
         terms: history, timeline, movement, evolution, change
+  custom_community:
+    _communities:
+      openhistoricalmap: OpenHistoricalMap
+    forum:
+      name: OpenHistoricalMap Forum
+      description: A shared place for conversations about OpenHistoricalMap


### PR DESCRIPTION
Replaced various OSM global community resources with their OHM analogues, including the OHM Forum in place of the OSM Community Forum and its regional categories. The hard-coded additions are based on entries in [this OSM Community Index distribution file](https://cdn.jsdelivr.net/npm/osm-community-index@5.5.0/dist/resources.min.json).

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/6f34ed4b-b5a6-4033-b300-f0db6412766b" width="399" alt="Success">

Fixes OpenHistoricalMap/issues#591.