### PR TITLE
Append date range to feature labels

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -760,6 +760,10 @@ en:
     lock:
       suggestion: 'The "{label}" field is locked because there is a Wikidata tag. You can delete it or edit the tags in the "Tags" section.'
     display_name:
+      # format for the label of a feature that has a name and date range
+      dated: "{name} [{dateRange}]"
+      # compact format for expressing a range of years
+      date_range: "{start}–{end}"
       direction: "{direction}"
       network: "{network}"
       from_to: "from {from} to {to}"

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -283,6 +283,16 @@ describe('iD.util', function() {
             // BART Yellow Line: Antioch => Pittsburg/Bay Point => SFO Airport => Millbrae
             expect(iD.utilDisplayName({tags: {network: 'BART', ref: 'Yellow', from: 'Antioch', to: 'Millbrae', via: 'Pittsburg/Bay Point;San Francisco International Airport', route: 'subway'}})).to.eql('BART Yellow from Antioch to Millbrae via Pittsburg/Bay Point;San Francisco International Airport');
         });
+        it('appends a date range', function() {
+            expect(iD.utilDisplayName({tags: {name: 'Arbre Perdu', 'name:en': 'Lost Tree'}})).to.eql('Lost Tree');
+            expect(iD.utilDisplayName({tags: {name: 'Arbre du Ténéré', 'name:en': 'Tree of Ténéré', start_date: '1673', end_date: '1973'}})).to.eql('Tree of Ténéré [1673–1973]');
+            expect(iD.utilDisplayName({tags: {name: 'Charter Oak', start_date: '1614', end_date: '1856-08-21'}})).to.eql('Charter Oak [1614–1856]');
+            expect(iD.utilDisplayName({tags: {name: 'Prometheus', start_date: '-2899', end_date: '1964-08'}})).to.eql('Prometheus [2900 BC–1964 AD]');
+            expect(iD.utilDisplayName({tags: {name: 'ජය ශ්‍රී මහා බෝධිය', 'name:en': 'Jaya Sri Maha Bodhi', start_date: '-287'}})).to.eql('Jaya Sri Maha Bodhi [288 BC–]');
+            expect(iD.utilDisplayName({tags: {name: 'Son of the Tree That Owns Itself', start_date: '1946-12-04'}})).to.eql('Son of the Tree That Owns Itself [1946–]');
+            expect(iD.utilDisplayName({tags: {name: 'Great Elm', end_date: '1876-02-15'}})).to.eql('Great Elm [–1876]');
+            expect(iD.utilDisplayName({tags: {name: 'Capitol Christmas Tree', start_date: '2021-11-19', end_date: '2021-12-25'}})).to.eql('Capitol Christmas Tree [2021]');
+        });
     });
 
     describe('utilOldestID', function() {


### PR DESCRIPTION
Feature labels now indicate the feature’s start and end years as applicable, wherever iD normally labels features, eliminating the need to hardcode date ranges inside `name`.

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/65359763-8e7d-4240-9542-a10a3e648dcc" width="600" alt="Map">
<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/e0a3517b-dd39-49eb-aff7-e63914cfe185" width="250" alt="Search" align="top">
<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/76e86d9e-bbae-4427-aac3-1bd382d4890f" width="250" alt="Members" align="top">
<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/06f2dbab-05c0-48a1-ad9f-d2eafe8dc28e" width="250" alt="Validator" align="top">

The date formats are localized by the browser based on the currently active locale:

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/0f6b9253-13bc-4f0f-8f32-84bc89cc0218" width="600" alt="Map in Chinese">

Fixes OpenHistoricalMap/issues#430.