### PR TITLE
Format dates according to user locales, not language

### DIFF
--- a/modules/ui/fields/date.js
+++ b/modules/ui/fields/date.js
@@ -22,7 +22,7 @@ export function uiFieldDate(field, context) {
 
     let edtfKey = field.key + ':edtf';
 
-    let dateTimeFormat = new Intl.DateTimeFormat(localizer.languageCode(), {
+    let dateTimeFormat = new Intl.DateTimeFormat(localizer.localeCodes(), {
         year: 'numeric',
         era: 'short',
         month: 'long',
@@ -37,7 +37,7 @@ export function uiFieldDate(field, context) {
      * @param year A representative year within the era.
      */
     function getEraName(year, format) {
-        let longFormat = new Intl.DateTimeFormat(localizer.languageCode(), {
+        let longFormat = new Intl.DateTimeFormat(localizer.localeCodes(), {
             year: 'numeric',
             era: format,
             timeZone: 'UTC',
@@ -76,7 +76,7 @@ export function uiFieldDate(field, context) {
 
     /// Returns the localized name of a month in the given format.
     function getMonthName(month, format) {
-        let longFormat = new Intl.DateTimeFormat(localizer.languageCode(), {
+        let longFormat = new Intl.DateTimeFormat(localizer.localeCodes(), {
             month: format,
             timeZone: 'UTC',
         });

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -41,7 +41,7 @@ export function validationFormatting() {
 
                     let alternatives = [];
                     if (normalized !== null) {
-                        let label = normalized.date.toLocaleDateString(localizer.languageCode(), normalized.localeOptions);
+                        let label = normalized.date.toLocaleDateString(localizer.localeCodes(), normalized.localeOptions);
                         alternatives.push({
                             date: normalized.value,
                             label: label || normalized.value,
@@ -51,7 +51,7 @@ export function validationFormatting() {
                     if (edtfFromOSM) {
                         let label;
                         try {
-                            label = edtf.default(edtfFromOSM).format(localizer.languageCode());
+                            label = edtf.default(edtfFromOSM).format(localizer.localeCode());
                         } catch (e) {
                             label = edtfFromOSM;
                         }
@@ -105,7 +105,7 @@ export function validationFormatting() {
             if (parserError.offset && parserError.token) {
                 message = t.append('issues.invalid_format.edtf.reference', {
                     token: parserError.token.value,
-                    position: (parserError.offset + 1).toLocaleString(localizer.languageCode()),
+                    position: (parserError.offset + 1).toLocaleString(localizer.localeCodes()),
                 });
             } else if (parserError.message) {
                 message = selection => selection.append('span')

--- a/modules/validations/mismatched_dates.js
+++ b/modules/validations/mismatched_dates.js
@@ -121,64 +121,7 @@ export function validationMismatchedDates() {
                 reference: showReferenceEDTF,
                 entityIds: [entity.id],
                 hash: key + entity.tags[key + ':edtf'],
-
-                dynamicFixes: function() {
-                    let fixes = [];
-                    let likelyDates = new Set();
-
-                    let valueFromDate = date => {
-                        date.precision = (parsed.lower || parsed.first || parsed).precision;
-                        return date.edtf.split('T')[0];
-                    };
-
-                    if (Number.isFinite(parsed.min)) {
-                        let min = edtf.default(parsed.min);
-                        likelyDates.add(valueFromDate(min));
-                    }
-
-                    if (Number.isFinite(parsed.max)) {
-                        let max = edtf.default(parsed.max);
-                        likelyDates.add(valueFromDate(max));
-                    }
-
-                    let sortedDates = [...likelyDates];
-                    sortedDates.sort();
-                    fixes.push(...sortedDates.map(value => {
-                        let normalized = utilNormalizeDateString(value);
-                        let localeDateString = normalized.date.toLocaleDateString(localizer.localeCodes(), normalized.localeOptions);
-                        return new validationIssueFix({
-                            title: t.append('issues.fix.reformat_date.title', { date: localeDateString }),
-                            onClick: function(context) {
-                                context.perform(function(graph) {
-                                    var entityInGraph = graph.hasEntity(entity.id);
-                                    if (!entityInGraph) return graph;
-                                    var newTags = Object.assign({}, entityInGraph.tags);
-                                    newTags[key] = normalized.value;
-                                    return actionChangeTags(entityInGraph.id, newTags)(graph);
-                                }, t('issues.fix.reformat_date.annotation'));
-                            }
-                        });
-                    }));
-
-                    fixes.push(new validationIssueFix({
-                        icon: 'iD-operation-delete',
-                        title: t.append('issues.fix.remove_tag.title'),
-                        onClick: function(context) {
-                            context.perform(function(graph) {
-                                var entityInGraph = graph.hasEntity(entity.id);
-                                if (!entityInGraph) return graph;
-                                var newTags = Object.assign({}, entityInGraph.tags);
-                                delete newTags[key];
-                                return actionChangeTags(entityInGraph.id, newTags)(graph);
-                            }, t('issues.fix.remove_tag.annotation'));
-                        }
-                    }));
-
-                    return fixes;
-                }
-
                 dynamicFixes: () => getDynamicFixes(key, parsed),
-      
             }));
         }
         validateEDTF('start_date', 'start');

--- a/modules/validations/mismatched_dates.js
+++ b/modules/validations/mismatched_dates.js
@@ -66,7 +66,7 @@ export function validationMismatchedDates() {
                     sortedDates.sort();
                     fixes.push(...sortedDates.map(value => {
                         let normalized = utilNormalizeDateString(value);
-                        let localeDateString = normalized.date.toLocaleDateString(localizer.languageCode(), normalized.localeOptions);
+                        let localeDateString = normalized.date.toLocaleDateString(localizer.localeCodes(), normalized.localeOptions);
                         return new validationIssueFix({
                             title: t.append('issues.fix.reformat_date.title', { date: localeDateString }),
                             onClick: function(context) {


### PR DESCRIPTION
Replaced the current language code with the array of preferred locale codes in the date fields and date-related validation rules added in OpenHistoricalMap/iD#185, OpenHistoricalMap/iD#187, and OpenHistoricalMap/iD#188.

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/3790c402-4a0e-46e6-9954-99ada504cf89" width="399" alt="Day, month, year, era">

Fixes OpenHistoricalMap/issues#670.