### PR TITLE
Fix bogus dates in labels and spurious mismatched date warnings and suggestions

### DIFF
--- a/modules/ui/fields/date.js
+++ b/modules/ui/fields/date.js
@@ -249,24 +249,26 @@ export function uiFieldDate(field, context) {
 
         if (!yearValue) {
             tag[field.key] = undefined;
-        } else if (isNaN(yearValue)) {
-            tag[field.key] = context.cleanTagValue(yearValue);
         } else {
             let value = '';
             let year = parseInt(context.cleanTagValue(yearValue), 10);
-            if (eraValue === bceName) {
-                value += '-' + String(year - 1).padStart(4, '0');
-            } else {
-                value += String(year).padStart(4, '0');
-            }
-            let month = context.cleanTagValue(monthValue);
-            if (monthNames.includes(month)) {
-                month = monthNames.indexOf(month) + 1;
-                value += '-' + String(month).padStart(2, '0');
-                let day = parseInt(context.cleanTagValue(dayValue), 10);
-                if (!isNaN(day)) {
-                    value += '-' + String(day).padStart(2, '0');
+            if (isNaN(year)) {
+                if (eraValue === bceName) {
+                    value += '-' + String(year - 1).padStart(4, '0');
+                } else {
+                    value += String(year).padStart(4, '0');
                 }
+                let month = context.cleanTagValue(monthValue);
+                if (monthNames.includes(month)) {
+                    month = monthNames.indexOf(month) + 1;
+                    value += '-' + String(month).padStart(2, '0');
+                    let day = parseInt(context.cleanTagValue(dayValue), 10);
+                    if (!isNaN(day)) {
+                        value += '-' + String(day).padStart(2, '0');
+                    }
+                }
+            } else {
+                value = context.cleanTagValue(yearValue);
             }
             tag[field.key] = value;
         }
@@ -424,7 +426,7 @@ export function uiFieldDate(field, context) {
             }
         }
 
-        utilGetSetValue(yearInput, typeof yearValue === 'number' ? yearValue : '')
+        utilGetSetValue(yearInput, (typeof yearValue === 'number' || typeof yearValue === 'string') ? yearValue : '')
             .attr('title', isMixed ? yearValue.filter(Boolean).join('\n') : null)
             .attr('placeholder', isMixed ? t('inspector.multiple_values') : t('inspector.date.year'))
             .classed('mixed', isMixed);

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -186,29 +186,31 @@ export function utilDisplayName(entity) {
         let start = entity.tags.start_date && utilNormalizeDateString(entity.tags.start_date);
         let end = entity.tags.end_date && utilNormalizeDateString(entity.tags.end_date);
 
-        // Keep the date range suffix succinct by only including the year and era.
-        let options = {timeZone: 'UTC'};
-        if (end) {
-            options.year = end.localeOptions.year;
-            options.era = end.localeOptions.era;
-        }
-        if (start) {
-            // Override any settings from the end of the range.
-            options.year = start.localeOptions.year;
-            options.era = start.localeOptions.era;
-        }
+        if (start || end) {
+            // Keep the date range suffix succinct by only including the year and era.
+            let options = {timeZone: 'UTC'};
+            if (end) {
+                options.year = end.localeOptions.year;
+                options.era = end.localeOptions.era;
+            }
+            if (start) {
+                // Override any settings from the end of the range.
+                options.year = start.localeOptions.year;
+                options.era = start.localeOptions.era;
+            }
 
-        // Get the date range format in structured form, then filter out anything untagged.
-        let format = new Intl.DateTimeFormat(localizer.languageCode(), options);
-        let lateDate = new Date(Date.UTC(9999));
-        let parts = format.formatRangeToParts(start ? start.date : lateDate, end ? end.date : lateDate);
-        if (!start) {
-            parts = parts.filter(p => p.source !== 'startRange');
+            // Get the date range format in structured form, then filter out anything untagged.
+            let format = new Intl.DateTimeFormat(localizer.languageCode(), options);
+            let lateDate = new Date(Date.UTC(9999));
+            let parts = format.formatRangeToParts(start ? start.date : lateDate, end ? end.date : lateDate);
+            if (!start) {
+                parts = parts.filter(p => p.source !== 'startRange');
+            }
+            if (!end) {
+                parts = parts.filter(p => p.source !== 'endRange');
+            }
+            dateRange = parts.map(p => p.value).join('');
         }
-        if (!end) {
-            parts = parts.filter(p => p.source !== 'endRange');
-        }
-        dateRange = parts.map(p => p.value).join('');
     }
 
     var localizedNameKey = 'name:' + localizer.languageCode().toLowerCase();

--- a/modules/validations/mismatched_dates.js
+++ b/modules/validations/mismatched_dates.js
@@ -20,19 +20,21 @@ export function validationMismatchedDates() {
     function getReplacementDates(parsed) {
         let likelyDates = new Set();
 
-        let valueFromDate = date => {
-            date.precision = (parsed.lower || parsed.first || parsed).precision;
+        let valueFromDate = (date, precision) => {
+            date.precision = precision;
             return date.edtf.split('T')[0];
         };
 
         if (Number.isFinite(parsed.min)) {
             let min = edtf.default(parsed.min);
-            likelyDates.add(valueFromDate(min));
+            let precision = (parsed.lower || parsed.first || parsed).precision;
+            likelyDates.add(valueFromDate(min, precision));
         }
 
         if (Number.isFinite(parsed.max)) {
             let max = edtf.default(parsed.max);
-            likelyDates.add(valueFromDate(max));
+            let precision = (parsed.upper || parsed.last || parsed).precision;
+            likelyDates.add(valueFromDate(max, precision));
         }
 
         let sortedDates = [...likelyDates];

--- a/modules/validations/mismatched_dates.js
+++ b/modules/validations/mismatched_dates.js
@@ -94,8 +94,9 @@ export function validationMismatchedDates() {
 
         function validateEDTF(key, msgKey) {
             if (!entity.tags[key] || !entity.tags[key + ':edtf']) return;
+            let basic = parseEDTF(entity.tags[key]);
             let parsed = parseEDTF(entity.tags[key + ':edtf']);
-            if (!parsed || parsed.covers(edtf.default(entity.tags[key]))) return;
+            if (!basic || !parsed || parsed.covers(basic)) return;
 
             issues.push(new validationIssue({
                 type: type,

--- a/modules/validations/mismatched_dates.js
+++ b/modules/validations/mismatched_dates.js
@@ -10,7 +10,18 @@ export function validationMismatchedDates() {
 
     function parseEDTF(value) {
         try {
-            return edtf.default(value);
+            let parsed = edtf.default(value);
+
+            // According to edtf.js, an extended interval with an unknown start or end covers no date.
+            // This isn't useful for the purpose of testing whether the basic date matches, so treat it as an unspecified start or end.
+            if (parsed.lower === null) {
+                parsed.lower = Infinity;
+            }
+            if (parsed.upper === null) {
+                parsed.upper = Infinity;
+            }
+
+            return parsed;
         } catch (e) {
             // Already handled by invalid_format rule.
             return;

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -292,6 +292,7 @@ describe('iD.util', function() {
             expect(iD.utilDisplayName({tags: {name: 'Son of the Tree That Owns Itself', start_date: '1946-12-04'}})).to.eql('Son of the Tree That Owns Itself [1946 – ]');
             expect(iD.utilDisplayName({tags: {name: 'Great Elm', end_date: '1876-02-15'}})).to.eql('Great Elm [ – 1876]');
             expect(iD.utilDisplayName({tags: {name: 'Capitol Christmas Tree', start_date: '2021-11-19', end_date: '2021-12-25'}})).to.eql('Capitol Christmas Tree [2021]');
+            expect(iD.utilDisplayName({tags: {name: 'Binary Search Tree', start_date: '0b0110', end_date: '0b0110'}})).to.eql('Binary Search Tree');
         });
     });
 

--- a/test/spec/validations/mismatched_dates.js
+++ b/test/spec/validations/mismatched_dates.js
@@ -53,6 +53,11 @@ describe('iD.validations.mismatched_dates', function () {
 
     it('suggests replacing date with bounds of EDTF range', function() {
         let validator = iD.validationMismatchedDates(context);
+        expect(validator.getReplacementDates(validator.parseEDTF('1234/..'))).to.deep.equal(['1234']);
+        expect(validator.getReplacementDates(validator.parseEDTF('../5678'))).to.deep.equal(['5678']);
         expect(validator.getReplacementDates(validator.parseEDTF('1234/5678'))).to.deep.equal(['1234', '5678']);
+        expect(validator.getReplacementDates(validator.parseEDTF('1234-10/5678'))).to.deep.equal(['1234-10', '5678']);
+        expect(validator.getReplacementDates(validator.parseEDTF('1234/5678-10-11'))).to.deep.equal(['1234', '5678-10-11']);
+        expect(validator.getReplacementDates(validator.parseEDTF('1234/5678-10-11T12:13:14'))).to.deep.equal(['1234', '5678-10-11']);
     });
 });

--- a/test/spec/validations/mismatched_dates.js
+++ b/test/spec/validations/mismatched_dates.js
@@ -51,6 +51,13 @@ describe('iD.validations.mismatched_dates', function () {
         expect(issue.entityIds[0]).to.eql('n-1');
     });
 
+    it('equates unknown date with unspecified date in EDTF extended interval', function() {
+        let validator = iD.validationMismatchedDates(context);
+        expect(validator.parseEDTF('/1234').toString()).to.equal(validator.parseEDTF('../1234').toString());
+        expect(validator.parseEDTF('5678/').toString()).to.equal(validator.parseEDTF('5678/..').toString());
+        expect(validator.parseEDTF('/').toString()).to.equal(validator.parseEDTF('../..').toString());
+    });
+
     it('suggests replacing date with bounds of EDTF range', function() {
         let validator = iD.validationMismatchedDates(context);
         expect(validator.getReplacementDates(validator.parseEDTF('1234/..'))).to.deep.equal(['1234']);

--- a/test/spec/validations/mismatched_dates.js
+++ b/test/spec/validations/mismatched_dates.js
@@ -50,4 +50,9 @@ describe('iD.validations.mismatched_dates', function () {
         expect(issue.entityIds).to.have.lengthOf(1);
         expect(issue.entityIds[0]).to.eql('n-1');
     });
+
+    it('suggests replacing date with bounds of EDTF range', function() {
+        let validator = iD.validationMismatchedDates(context);
+        expect(validator.getReplacementDates(validator.parseEDTF('1234/5678'))).to.deep.equal(['1234', '5678']);
+    });
 });


### PR DESCRIPTION
This PR fixes several errata from #187:

* The mismatched dates validator now suggests dates that match the precision of the EDTF date.
* Fixed an uncaught exception when the `start_date` or `end_date` value is malformed.
* Feature labels now omit malformed dates.
* The mismatched dates validator no longer flags dates that fall within an EDTF extended interval just because the extended interval has an unknown start or end.

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/db8cae34-df90-4183-b298-4252769f6ad7" width="399" alt="Tag as 1800; Tag as April 1900">

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/88c1fcc0-38bf-4349-8a76-660eb59c005d" width="399" alt="Meade House has an invalid start date"> <img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/18b46de1-1589-4af9-9c30-a5ea572e2e26" width="399" alt="/1906-04">

Fixes OpenHistoricalMap/issues#674 and fixes OpenHistoricalMap/issues#675.