### PR TITLE
Fix tests

### DIFF
--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -23,7 +23,9 @@ export { _mainPresetIndex as presetManager };
  * Sets preset defaults specific to OpenHistoricalMap.
  */
 function setHistoricalDefaults(defaults) {
-  defaults.relation.unshift('type/chronology');
+  if (defaults.relation) {
+    defaults.relation.unshift('type/chronology');
+  }
 }
 
 /**
@@ -45,14 +47,18 @@ function addHistoricalPresets(presets) {
  * Adds fields specific to OpenHistoricalMap.
  */
 function addHistoricalFields(fields) {
-  fields.start_date.type = 'date';
-  fields.end_date = {
-    ...fields.start_date,
-    key: 'end_date'
-  };
+  if (fields.start_date) {
+    fields.start_date.type = 'date';
+    fields.end_date = {
+      ...fields.start_date,
+      key: 'end_date'
+    };
+  }
 
   // A combo box would encourage mappers to choose one of the suggestions, but we want mappers to be as detailed as possible.
-  fields.source.type = 'text';
+  if (fields.source) {
+    fields.source.type = 'text';
+  }
 
   fields.license = {
     key: 'license',

--- a/modules/services/osm_wikibase.js
+++ b/modules/services/osm_wikibase.js
@@ -105,7 +105,7 @@ export default {
         } else {
             prefix = type + ':';
         }
-        return prefix + (value ? `${key}=${value}` : key).replace(/_/g, ' ').trim();
+        return (prefix + (value ? `${key}=${value}` : key).replace(/_/g, ' ')).trim();
     },
 
 

--- a/test/spec/services/osm_wikibase.js
+++ b/test/spec/services/osm_wikibase.js
@@ -284,7 +284,7 @@ describe('iD.serviceOsmWikibase', function () {
           {
             action: 'wbgetentities',
             sites: 'wiki',
-            titles: 'Locale:fr|Key:amenity|Tag:amenity=parking',
+            titles: 'Locale:fr|Key:amenity|OpenHistoricalMap/Tags/Key/amenity|Tag:amenity=parking|OpenHistoricalMap/Tags/Tag/amenity=parking',
             languages: 'fr',
             languagefallback: '1',
             origin: '*',

--- a/test/spec/spec_helpers.js
+++ b/test/spec/spec_helpers.js
@@ -83,6 +83,7 @@ iD.localizer.loadLocale('en', 'tagging');
 
 // Initializing `coreContext` initializes `_background`, which tries loading:
 cached.imagery = [];
+cached.wayback = {};
 // Initializing `coreContext` initializes `_presets`, which tries loading:
 cached.preset_categories = {};
 cached.preset_defaults = {};


### PR DESCRIPTION
Fixed 28 failures and several warnings in tests. #145 and #178 didn’t account for the mocked preset tables lacking the presets we wanted to modify, and also didn’t update the tests for finding documentation on the wiki. Similarly, #181 didn’t mock one of the files that iD normally fetches over the network, so the test harness was fetching it over the network and complaining about it.

Fixes OpenHistoricalMap/issues#720 and fixes OpenHistoricalMap/issues#721.