### PR TITLE
Only load English as fallback localization

### DIFF
--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -120,7 +120,9 @@ export function coreLocalizer() {
                 indexes.forEach((index, i) => {
                     // Will always return the index for `en` if nothing else
                     const fullCoverageIndex = _localeCodes.findIndex(function(locale) {
-                        return index[locale] && index[locale].pct === 1;
+                        // Only English contains everything including the OpenHistoricalMap additions, because we haven’t set up a translation management system yet.
+                        // https://github.com/OpenHistoricalMap/issues/issues/470
+                        return locale === 'en' && index[locale] && index[locale].pct === 1;
                     });
                     // We only need to load locales up until we find one with full coverage
                     _localeCodes.slice(0, fullCoverageIndex + 1).forEach(function(code) {


### PR DESCRIPTION
Until we configure a translation management system, English is the only localization with complete coverage including OpenHistoricalMap’s custom strings, so iD will only load English as the fallback localization, not any other language that has 100% coverage in OpenStreetMap’s version of iD (currently German, Spanish, Traditional Chinese, or Ukrainian). This change is important for keeping the UI usable but comes with the downside that a locale very similar to one of those four locales will fall back to a much different language, English, for every missing string, not just the ones that are custom to OHM.

<img src="https://github.com/OpenHistoricalMap/iD/assets/1231218/6db35040-3522-49d9-a4ab-24cd0329613e" width="399" alt="End Date">

Fixes OpenHistoricalMap/issues#713.