### PR TITLE
Addresses #722 Configure continuous integration for iD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,8 @@ name: build
 
 on:
   push:
-    branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ staging, release ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Changing the config so that a push to any branch or a PR to `staging` or `release` kicks off a build.