### PR TITLE
Avoid propagating invalid date

### DIFF
--- a/modules/util/date.js
+++ b/modules/util/date.js
@@ -70,6 +70,9 @@ export function utilNormalizeDateString(raw) {
         date.setUTCFullYear(parseInt((match[1] || '') + match[2], 10));
         if (match[3]) date.setUTCMonth(parseInt(match[3], 10) - 1); // 0-based
         if (match[4]) date.setUTCDate(parseInt(match[4], 10));
+        if (isNaN(date.getDate())) {
+            return null;
+        }
     } else {
         // Fall back on whatever the browser can parse into a date.
         date = new Date(raw);

--- a/test/spec/util/date.js
+++ b/test/spec/util/date.js
@@ -55,6 +55,8 @@ describe('iD.date', function() {
         it('rejects malformed dates', function() {
             expect(iD.utilNormalizeDateString('1970-01--1')).to.eql(null);
             expect(iD.utilNormalizeDateString('197X')).to.eql(null); // no EDTF for now
+            // https://github.com/OpenHistoricalMap/issues/issues/826
+            expect(iD.utilNormalizeDateString('1912091095')).to.eql(null);
         });
         it('respects the original precision', function() {
             expect(iD.utilNormalizeDateString('123').value).to.eql('0123');


### PR DESCRIPTION
If a `start_date` or `end_date` value matches the ISO&nbsp;8601 regular expression but is still somehow malformed, `utilNormalizeDateString()` now returns null, which will avoid downstream errors in code that tries to use the `Date` object for something meaningful and also trip the invalid date validator rule.

Fixes OpenHistoricalMap/issues#826.