### PR TITLE
Allow EDTF date to refine basic date with time

### DIFF
--- a/modules/validations/mismatched_dates.js
+++ b/modules/validations/mismatched_dates.js
@@ -105,9 +105,15 @@ export function validationMismatchedDates() {
 
         function validateEDTF(key, msgKey) {
             if (!entity.tags[key] || !entity.tags[key + ':edtf']) return;
-            let basic = parseEDTF(entity.tags[key]);
+            let basic = entity.tags[key];
+            // start_date and end_date disallow time precision. Transform the basic date into a daylong range in EDTF to allow a comparison to an EDTF date with time precision.
+            // https://github.com/OpenHistoricalMap/issues/issues/764
+            if (basic.match('^-?[0-9]+-[0-9]{2}-[0-9]{2}$')) {
+                basic = `${basic}T00:00:00/${basic}T24:00:00`;
+            }
+            let basicAsEDTF = parseEDTF(basic);
             let parsed = parseEDTF(entity.tags[key + ':edtf']);
-            if (!basic || !parsed || parsed.covers(basic)) return;
+            if (!basicAsEDTF || !parsed || parsed.covers(basicAsEDTF) || basicAsEDTF.covers(parsed)) return;
 
             issues.push(new validationIssue({
                 type: type,

--- a/test/spec/validations/mismatched_dates.js
+++ b/test/spec/validations/mismatched_dates.js
@@ -51,6 +51,18 @@ describe('iD.validations.mismatched_dates', function () {
         expect(issue.entityIds[0]).to.eql('n-1');
     });
 
+    it('ignores way with date narrowed by EDTF time range', function() {
+        createNode({ shop: 'mall', name: 'Forest Fair Mall', start_date: '1988-07-11', 'start_date:edtf': '1988-07-11T10:00', end_date: '2003-06-10', 'end_date:edtf': '2003-06-10T08:00/2003-06-10T21:00' });
+        let issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('flags way with date outside of EDTF time range', function() {
+        createNode({ shop: 'mall', name: 'Forest Fair Mall', start_date: '1988-07-11', 'start_date:edtf': '1988-07-12', end_date: '2003-06-11', 'end_date:edtf': '2003-06-10T08:00/2003-06-10T21:00' });
+        let issues = validate();
+        expect(issues).to.have.lengthOf(2);
+    });
+
     it('equates unknown date with unspecified date in EDTF extended interval', function() {
         let validator = iD.validationMismatchedDates(context);
         expect(validator.parseEDTF('/1234').toString()).to.equal(validator.parseEDTF('../1234').toString());


### PR DESCRIPTION
If a `start_date` or `end_date` has been qualified to the fullest extent possible (down to the day), treat it as a daylong range in EDTF when comparing it to the `start_date:edtf` or `end_date:edtf` tag, and compare it both ways to see if there’s any overlap.

Originally, I wanted to just append `TXX:XX` to the basic date, but either EDTF.js or the EDTF specification apparently doesn’t allow unspecified digits (`X`) within time specifiers. It also wasn’t practical to ignore the time when parsing the EDTF date, because the EDTF date can contain a whole range or set of dates with time precision, not just one. Fortunately, at least EDTF.js seems to recognize 24:00:00 as a synonym for midnight that does not roll over into the following day, per ISO&nbsp;8601-1:2019/Amd&nbsp;1:2022.

Fixes OpenHistoricalMap/issues#764.