### PR TITLE
Update sources field

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1597,6 +1597,12 @@ input.date-selector {
     border-radius: 0;
     line-height: 0.95rem;
 }
+.form-field ul.rows li.labeled-input div > span{
+    vertical-align: middle;
+}
+.form-field ul.rows li.labeled-input-source > div {
+    width: auto;
+}
 .form-field ul.rows li input {
     border-radius: 0;
     border-width: 0;
@@ -2051,6 +2057,9 @@ input.date-selector {
 
 /* Field - date, roadheight, and roadspeed
 ------------------------------------------------------- */
+.form-field-input-source {
+    flex-direction: column;
+}
 .form-field-input-date input.date-year,
 .form-field-input-date input.date-month,
 .form-field-input-roadheight input.roadheight-number,
@@ -2959,6 +2968,10 @@ img.tag-reference-wiki-image {
 .add-row .add-relation,
 .add-row .space-value {
     flex: 1 1 50%;
+}
+.add-row .add-subkey {
+    width: 32px;
+    flex: 0 1 auto;
 }
 .add-row .space-buttons {
     flex: 0 0 62px;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1591,13 +1591,15 @@ input.date-selector {
     display: flex;
     flex-flow: row nowrap;
 }
-.form-field ul.rows li.labeled-input > div {
+.form-field ul.rows li.labeled-input > div,
+.form-field ul.rows li.labeled-input-source > div {
     flex: 1 1 auto;
     width: 100%;
     border-radius: 0;
     line-height: 0.95rem;
 }
-.form-field ul.rows li.labeled-input div > span{
+.form-field ul.rows li.labeled-input div > span,
+.form-field ul.rows li.labeled-input-source div > span{
     vertical-align: middle;
 }
 .form-field ul.rows li.labeled-input-source > div {
@@ -1626,10 +1628,12 @@ input.date-selector {
     display: table;
     width: 100%;
 }
-.form-field ul.rows.rows-table li.labeled-input {
+.form-field ul.rows.rows-table li.labeled-input,
+.form-field ul.rows.rows-table li.labeled-input-source {
     display: table-row;
 }
-.form-field ul.rows.rows-table li.labeled-input > div:first-child {
+.form-field ul.rows.rows-table li.labeled-input > div:first-child,
+.form-field ul.rows.rows-table li.labeled-input-source > div:first-child {
     display: table-cell;
     width: auto;
     max-width: 170px;
@@ -1637,7 +1641,8 @@ input.date-selector {
     text-overflow: ellipsis;
     overflow: hidden;
 }
-.form-field ul.rows.rows-table li.labeled-input > div:nth-child(2) {
+.form-field ul.rows.rows-table li.labeled-input > div:nth-child(2),
+.form-field ul.rows.rows-table li.labeled-input-source > div:nth-child(2) {
     display: table-cell;
     width: auto;
 }

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -802,9 +802,9 @@ en:
     field_source_label: Source for {field_name}
     field_source_placeholder: URL, newspaper article, book...
     source:
-      main_input: General source
-      name: Name of the source
-      url: https://xyz.com
+      main_input: Description
+      name: Name
+      url: https://example.com
       date: Date the source was created
     max_length_reached: "This string is longer than the maximum length of {maxChars} characters. Anything exceeding that length will be truncated."
     set_today: "Sets the value to today."
@@ -2530,11 +2530,6 @@ en:
     identifier: "Identifier"
     label: "Label"
     description: "Description"
-  source:
-    name: "Name"
-    date: "Date"
-    url: "URL"
-    geometry: "Geometry"
   custom_presets:
     fields:
       end_date:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2540,6 +2540,8 @@ en:
         label: License
         placeholder: CC0
         terms: copyleft, copyright
+      source:
+        label: Source
     presets:
       type/chronology:
         name: Chronology

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -801,6 +801,10 @@ en:
     field_source: add source
     field_source_label: Source for {field_name}
     field_source_placeholder: URL, newspaper article, book...
+    source:
+      name: Name of the source
+      url: https://xyz.com
+      date: Date the source was created
     max_length_reached: "This string is longer than the maximum length of {maxChars} characters. Anything exceeding that length will be truncated."
     set_today: "Sets the value to today."
   background:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -802,6 +802,7 @@ en:
     field_source_label: Source for {field_name}
     field_source_placeholder: URL, newspaper article, book...
     source:
+      main_input: General source
       name: Name of the source
       url: https://xyz.com
       date: Date the source was created

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2525,6 +2525,11 @@ en:
     identifier: "Identifier"
     label: "Label"
     description: "Description"
+  source:
+    name: "Name"
+    date: "Date"
+    url: "URL"
+    geometry: "Geometry"
   custom_presets:
     fields:
       end_date:

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -57,7 +57,7 @@ function addHistoricalFields(fields) {
 
   // A combo box would encourage mappers to choose one of the suggestions, but we want mappers to be as detailed as possible.
   if (fields.source) {
-    fields.source.type = 'text';
+    fields.source.type = 'source';
     fields.source.source = false;
   }
 

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -59,6 +59,7 @@ function addHistoricalFields(fields) {
   if (fields.source) {
     fields.source.type = 'source';
     fields.source.source = false;
+    fields.source.keys = ['source', 'source:url', 'source:name', 'source:date'];
   }
 
   fields.license = {

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -54,6 +54,7 @@ import { uiFieldLocalized } from './localized';
 import { uiFieldRoadheight } from './roadheight';
 import { uiFieldRoadspeed } from './roadspeed';
 import { uiFieldRestrictions } from './restrictions';
+import { uiFieldSources } from './sources';
 import { uiFieldTextarea } from './textarea';
 import { uiFieldWikidata } from './wikidata';
 import { uiFieldWikipedia } from './wikipedia';
@@ -82,6 +83,7 @@ export var uiFields = {
     radio: uiFieldRadio,
     restrictions: uiFieldRestrictions,
     semiCombo: uiFieldSemiCombo,
+    source: uiFieldSources,
     structureRadio: uiFieldStructureRadio,
     tel: uiFieldTel,
     text: uiFieldText,

--- a/modules/ui/fields/sources.js
+++ b/modules/ui/fields/sources.js
@@ -14,8 +14,8 @@ export function uiFieldSources(field, context) {
     const mainKey = 'source';
     const sourceHeader = mainKey + ':';
 
-    // Pre-selected subkey values to show
-    const possibleSourceSubkeys = [{key:'name', value:'Name'}, {key:'url', value:'URL'}, {key:'date', value:'Date'}];
+    // Pre-selected subkeys to show
+    const possibleSourceSubkeys = [{key:'name'}, {key:'url'}, {key:'date'}];
 
     function scheduleChange() {
         if (!_pendingChange) return;

--- a/modules/ui/fields/sources.js
+++ b/modules/ui/fields/sources.js
@@ -21,7 +21,7 @@ export function uiFieldSources(field, context) {
     const sourceHeader = 'source:';
 
     const possibleSourceSubkeys = [{key:'name', value:'Name'}, {key:'url', value:'URL'}, {key:'date', value:'Date'}]
-    
+
     function addSubkey() {
         if(sourceSubkeys.length < possibleSourceSubkeys.length){
             var newKey = possibleSourceSubkeys.filter((k) => sourceSubkeys.map(e => e.key).indexOf(k.key) === -1)[0];
@@ -183,6 +183,9 @@ export function uiFieldSources(field, context) {
             .append('input')
             .attr('type', 'text')
             .attr('class', 'value')
+            .attr('placeholder', function(d) {
+                return t('inspector.source.' + d.key)
+            })
             .call(utilNoAuto)
             .call(utilGetSetValue, function(d) { return _tags[sourceHeader + d.key]; })
             .on('change', valueChange)

--- a/modules/ui/fields/sources.js
+++ b/modules/ui/fields/sources.js
@@ -1,0 +1,228 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
+
+import { svgIcon } from '../../svg';
+import { uiTooltip } from '../tooltip';
+import { uiCombobox } from '../combobox';
+import { uiFieldMultiCombo } from './combo';
+import { t, localizer } from '../../core/localizer';
+import { utilGetSetValue, utilNoAuto, utilRebind, utilUniqueDomId } from '../../util';
+
+
+export function uiFieldSources(field, context) {
+    let dispatch = d3_dispatch('change');
+    let yearInput = d3_select(null);
+    let eraInput = d3_select(null);
+    let monthInput = d3_select(null);
+    let dayInput = d3_select(null);
+    let edtfInput = d3_select(null);
+    let _entityIDs = [];
+    let _tags;
+    let _selection = d3_select(null);
+    let _edtfValue;
+
+
+    let possibleSourceSubkeys = [{value:'Name', title:'Name'}, {value:'URL', title:'URL'}, {value:'Date', title:'Date'}]
+    let sourceSubkeysNotInUse = ['name', 'url', 'date']
+    let sourceSubkeysInUse = []
+
+    /**
+     * Returns the localized name of the era in the given format.
+     *
+     * @param year A representative year within the era.
+     */
+
+    function addSubkey() {
+        console.log('in add');
+        console.log(sourceSubkeys.length);
+        if(sourceSubkeys.length < possibleSourceSubkeys.length){
+            var newKey = possibleSourceSubkeys.filter((key) => sourceSubkeys.map(e => e.value).indexOf(key.value) === -1)[0];
+            _tags['source:'+ newKey.value] = '';
+            _selection.call(sources);
+        }
+
+    }
+
+    function sources(selection) {
+        console.log(_tags);
+        console.log(typeof(_tags));
+        _selection = selection;
+
+        sourceSubkeys = _tags ? Object.keys(_tags)
+        .filter((key, value) => key.indexOf('source:') === 0)
+        .map((tag) => {
+            return {value: tag.slice(7), title: tag.slice(7)}
+        })
+        : 
+        [];
+
+        console.log(sourceSubkeys);
+
+        var wrap = selection.selectAll('.form-field-input-wrap')
+            .data([0]);
+
+        wrap = wrap.enter()
+            .append('div')
+            .attr('class', 'form-field-input-wrap form-field-input-' + field.type)
+            .merge(wrap);
+
+        mainInput = wrap.selectAll('input')
+        .data([0])
+        .enter()
+        .append('input')
+        .attr('type', 'text')
+        .attr('placeholder', 'Unknown')
+        .call(utilNoAuto);
+
+        var list = wrap.selectAll('ul')
+        .data([0]);
+
+        list = list.enter()
+            .append('ul')
+            .attr('class', 'rows')
+            .merge(list);
+
+        list = list.merge(list);
+        
+        var items = list.selectAll('li.labeled-input')
+            .data(sourceSubkeys);
+
+        // Enter
+        
+        var enter = items.enter()
+            .append('li')
+            .attr('class', 'labeled-input labeled-input-source');
+
+        enter
+            .append('input')
+            .attr('type', 'text')
+            .call(utilNoAuto)
+            .each(function(d) {
+                var key = d3_select(this);
+                let combo = uiCombobox(context, 'tag-key');
+                combo.data(possibleSourceSubkeys.filter((key) => sourceSubkeys.indexOf(key) === -1));
+                combo
+                key.call(combo);
+            })
+            .attr('title', function(d) { return d.title; })
+            .call(utilGetSetValue, function(d) { return d.value; });
+
+        enter
+            .append('input')
+            .attr('type', 'text')
+            .call(utilNoAuto);
+
+        enter
+            .append('button')
+            .attr('class', 'form-field-button remove')
+            .attr('title', t('icons.remove'))
+            .call(svgIcon('#iD-operation-delete'));
+
+        // Enter
+        // var itemsEnter = items.enter()
+        //     .append('li')
+        //     .attr('class', 'tag-row');
+
+        // var innerWrap = itemsEnter.append('div')
+        //     .attr('class', 'inner-wrap');
+
+        
+            
+        // innerWrap
+        //     .append('div')
+        //     .attr('class', 'key-wrap')
+        //     .append('input')
+        //     .property('type', 'text')
+        //     .attr('class', 'key')
+        //     .call(utilNoAuto)
+        //     .call(combo);
+
+        // innerWrap
+        //     .append('div')
+        //     .attr('class', 'value-wrap')
+        //     .append('input')
+        //     .property('type', 'text')
+        //     .attr('class', 'value')
+        //     .call(utilNoAuto);
+
+        // innerWrap
+        //     .append('button')
+        //     .attr('class', 'form-field-button remove')
+        //     .attr('title', t('icons.remove'))
+        //     .call(svgIcon('#iD-operation-delete'));
+
+        // items
+        //     .each(function(d) {
+        //         var row = d3_select(this);
+        //         var key = row.select('input.key');      // propagate bound data
+        //         var value = row.select('input.value');  // propagate bound data
+
+        //         if (_entityIDs && taginfo && _state !== 'hover') {
+        //             bindTypeahead(key, value);
+        //         }
+
+        //         var referenceOptions = { key: d.key };
+        //         if (typeof d.value === 'string') {
+        //             referenceOptions.value = d.value;
+        //         }
+        //         var reference = uiTagReference(referenceOptions, context);
+
+        //         if (_state === 'hover') {
+        //             reference.showing(false);
+        //         }
+
+        //         row.select('.inner-wrap')      // propagate bound data
+        //             .call(reference.button);
+
+        //         row.call(reference.body);
+
+        //         row.select('button.remove');   // propagate bound data
+        //     });
+
+        // Container for the Add button
+        console.log("in button");
+        console.log(sourceSubkeys.length);
+        console.log(possibleSourceSubkeys.length);
+        console.log(sourceSubkeys.length < possibleSourceSubkeys.length);
+        if(sourceSubkeys.length < possibleSourceSubkeys.length){
+        
+            var addRowEnter = wrap.selectAll('.add-row')
+                .data([0])
+                .enter()
+                .append('div')
+                .attr('class', 'add-row');
+    
+            addRowEnter
+                .append('button')
+                .attr('class', 'add-tag add-subkey')
+                .attr('aria-label', t('inspector.add_to_tag'))
+                .call(svgIcon('#iD-icon-plus', 'light'))
+                .call(uiTooltip()
+                    .title(() => t.append('inspector.add_to_tag'))
+                    .placement(localizer.textDirection() === 'ltr' ? 'right' : 'left'))
+                .on('click', addSubkey);
+    
+            addRowEnter
+                .append('div')
+                .attr('class', 'space-value');
+                  // preserve space
+    
+            addRowEnter
+                .append('div')
+                .attr('class', 'space-value');  // preserve space
+            
+        }
+        else {
+            _selection.selectAll('.add-row').remove();
+
+        }
+        
+
+    }
+
+    sources.tags = function(tags){
+        _tags = tags;
+    }
+
+    return utilRebind(sources, dispatch, 'on');
+}

--- a/modules/ui/fields/sources.js
+++ b/modules/ui/fields/sources.js
@@ -101,6 +101,9 @@ export function uiFieldSources(field, context) {
             .append('input')
             .attr('type', 'text')
             .attr('class', 'value')
+            .attr('placeholder', function(d) {
+                return t('inspector.source.' + d.key);
+            })
             .call(utilNoAuto)
             .call(utilGetSetValue, function(d) {
                 return _tags[sourceHeader + d.key];
@@ -112,14 +115,11 @@ export function uiFieldSources(field, context) {
             .remove();
 
         utilGetSetValue(_selection.selectAll('.value'), function(d) {
-                return _tags[sourceHeader + d.key];
-            })
-            .attr('placeholder', function(d) {
-                return t('inspector.source.' + d.key);
+                return (_tags[sourceHeader + d.key] === undefined) ? '' : _tags[sourceHeader + d.key];
         });
 
         utilGetSetValue(_selection.selectAll('.main-value'), function() {
-            return _tags[mainKey];
+            return (_tags[mainKey] === undefined) ? '' : _tags[mainKey];
         });
     }
 

--- a/modules/ui/fields/sources.js
+++ b/modules/ui/fields/sources.js
@@ -1,57 +1,26 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
 
-import { svgIcon } from '../../svg';
-import { uiTooltip } from '../tooltip';
-import { uiCombobox } from '../combobox';
-import { uiFieldMultiCombo } from './combo';
-import { t, localizer } from '../../core/localizer';
-import { utilGetSetValue, utilNoAuto, utilRebind, utilUniqueDomId } from '../../util';
-
+import { t } from '../../core/localizer';
+import { utilGetSetValue, utilNoAuto, utilRebind } from '../../util';
 
 export function uiFieldSources(field, context) {
     let dispatch = d3_dispatch('change');
     let items = d3_select(null);
-    let enter = d3_select(null);
     let _tags = {};
     let _selection = d3_select(null);
     let _pendingChange;
 
     const mainKey = 'source';
-    const sourceHeader = 'source:';
+    const sourceHeader = mainKey + ':';
 
-    const possibleSourceSubkeys = [{key:'name', value:'Name'}, {key:'url', value:'URL'}, {key:'date', value:'Date'}]
-
-    function addSubkey() {
-        if(sourceSubkeys.length < possibleSourceSubkeys.length){
-            var newKey = possibleSourceSubkeys.filter((k) => sourceSubkeys.map(e => e.key).indexOf(k.key) === -1)[0];
-            _tags[sourceHeader + newKey.key] = '';
-            scheduleChange();
-            _selection.call(sources);
-        }
-    }
-
-    function getKeyFromTitle(title) {
-        return possibleSourceSubkeys.filter((e) => e.value == title)[0].key;
-    }
+    // Pre-selected subkey values to show
+    const possibleSourceSubkeys = [{key:'name', value:'Name'}, {key:'url', value:'URL'}, {key:'date', value:'Date'}];
 
     function scheduleChange() {
-        // Delay change in case this change is blurring an edited combo. - #5878
-
         if (!_pendingChange) return;
-        window.setTimeout(function() {
-            dispatch.call('change', this, _pendingChange);
-            _pendingChange = null;
-            _selection.call(sources);
-        }, 20);
-    }
-
-    function removeTag(d3_event, d) {
-        _pendingChange  = _pendingChange || {};
-        key = sourceHeader + d.key;
-        _pendingChange[key] = undefined;
-        delete _tags[key];
-        scheduleChange();
+        dispatch.call('change', this, _pendingChange);
+        _pendingChange = null;
         _selection.call(sources);
     }
 
@@ -63,75 +32,50 @@ export function uiFieldSources(field, context) {
 
         _pendingChange = _pendingChange || {};
 
-        _pendingChange[key] = context.cleanTagValue(this.value);
-        _tags[key] = context.cleanTagValue(this.value);
+        var value = context.cleanTagValue(this.value);
+
+        _pendingChange[key] = value === '' ? undefined : value;
+        _tags[key] = value === '' ? undefined : value;
         scheduleChange();
     }
 
-    function keyChange(d3_event, d) {
-        var kOld = sourceHeader + d.key;
-        var kNew = sourceHeader + getKeyFromTitle(context.cleanTagKey(this.value.trim()));
-
+    function mainChange() {
         _pendingChange = _pendingChange || {};
-
-        if (kOld && _tags[kOld]) {
-            if (kOld === kNew) return;
-            // a tag key was renamed
-            _pendingChange[kNew] = _tags[kOld];
-            _tags[kNew] = _tags[kOld];
-            _pendingChange[kOld] = undefined;
-            _tags[kOld] = undefined;
-        } else {
-            // a new tag was added
-            let row = this.parentNode;
-            let inputVal = d3_select(row).selectAll('input.value');
-            let vNew = context.cleanTagValue(utilGetSetValue(inputVal));
-            _pendingChange[kNew] = vNew;
-            utilGetSetValue(inputVal, vNew);
-        }
-        var newDatum = possibleSourceSubkeys.filter((e) => e.key == kNew.slice(7))[0];
-        d.key = newDatum.key;
-        d.value = newDatum.value;
-        scheduleChange();
-    }
-
-    function mainChange(d3_event, d) {
-        _pendingChange = _pendingChange || {};
-        _pendingChange[mainKey] = context.cleanTagValue(this.value);
+        var value = context.cleanTagValue(this.value);
+        _pendingChange[mainKey] = value === '' ? undefined : value;
+        _tags[mainKey] = value === '' ? undefined : value;
         scheduleChange();
     }
 
     function sources(selection) {
         _selection = selection;
 
-        sourceSubkeys = _tags ? Object.keys(_tags)
-        .filter((key, value) => (key.indexOf(sourceHeader) === 0))
-        .map((tag) => {
-            var data =  possibleSourceSubkeys.filter((e) => e.key == tag.slice(7))[0];
-            return {
-                value: data.value,
-                key: data.key
-            };
-        })
-        : 
-        [];
-
         var wrap = selection.selectAll('.form-field-input-wrap')
             .data([0]);
+
+        selection.exit()
+            .style('top', '0')
+            .style('max-height', '240px')
+            .transition()
+            .duration(200)
+            .style('opacity', '0')
+            .style('max-height', '0px')
+            .remove();
 
         wrap = wrap.enter()
             .append('div')
             .attr('class', 'form-field-input-wrap form-field-input-' + field.type)
             .merge(wrap);
 
-        mainInput = wrap.selectAll('input')
+        // source key
+        wrap.selectAll('input')
         .data([0])
         .enter()
         .append('input')
+        .attr('class', 'main-value')
         .attr('type', 'text')
-        .attr('placeholder', 'Unknown')
+        .attr('placeholder', t('inspector.source.main_input'))
         .call(utilNoAuto)
-        .call(utilGetSetValue, function(d) {return _tags[mainKey]})
         .on('change', mainChange)
         .on('blur', mainChange);
 
@@ -145,84 +89,38 @@ export function uiFieldSources(field, context) {
 
         list = list.merge(list);
 
-        list.selectAll('li.labeled-input').remove();
-        
-        items = list.selectAll('li.labeled-input')
-            .data(sourceSubkeys);
+        // source:*= keys
+        items = list.selectAll('li.labeled-input-source')
+            .data(possibleSourceSubkeys);
 
-        items.exit()
-        .remove();
-        
-        enter = items.enter()
+        items = items.enter()
             .append('li')
-            .attr('class', 'labeled-input labeled-input-source');
+            .attr('class', 'labeled-input-source');
 
-        enter
-            .append('input')
-            .attr('type', 'text')
-            .call(utilNoAuto)
-            .each(function(d) {
-                var key = d3_select(this);
-                let combo = uiCombobox(context, 'tag-key');
-                combo.fetcher(function(value, callback) {
-                    var keyString = utilGetSetValue(key);
-                    var data = possibleSourceSubkeys.filter((key) => 
-                        sourceSubkeys
-                        .map((e) => e.key)
-                        .indexOf(key.key) === -1);
-                    callback(data);
-                });
-                combo.minItems(1);
-                key.call(combo)
-                .on('change', keyChange)
-                .on('blur', keyChange)
-                .call(utilGetSetValue, function(d) { return d.value; });
-            });
-
-        enter
+        items
             .append('input')
             .attr('type', 'text')
             .attr('class', 'value')
-            .attr('placeholder', function(d) {
-                return t('inspector.source.' + d.key)
-            })
             .call(utilNoAuto)
-            .call(utilGetSetValue, function(d) { return _tags[sourceHeader + d.key]; })
+            .call(utilGetSetValue, function(d) {
+                return _tags[sourceHeader + d.key];
+            })
             .on('change', valueChange)
             .on('blur', valueChange);
 
-        enter
-            .append('button')
-            .attr('class', 'form-field-button remove')
-            .attr('title', t('icons.remove'))
-            .call(svgIcon('#iD-operation-delete'))
-            .on('click', removeTag);
+        items.exit()
+            .remove();
 
-        // Container for the Add button
-        if(sourceSubkeys.length < possibleSourceSubkeys.length){
-        
-            var addRowEnter = wrap.selectAll('.add-row')
-                .data([0])
-                .enter()
-                .append('div')
-                .attr('class', 'add-row');
-    
-            addRowEnter
-                .append('button')
-                .attr('class', 'add-tag add-subkey')
-                .attr('aria-label', t('inspector.add_to_tag'))
-                .call(svgIcon('#iD-icon-plus', 'light'))
-                .call(uiTooltip()
-                    .title(() => t.append('inspector.add_to_tag'))
-                    .placement(localizer.textDirection() === 'ltr' ? 'right' : 'left'))
-                .on('click', addSubkey);
-            
-        }
-        else {
-            _selection.selectAll('.add-row').remove();
-        }
-        
+        utilGetSetValue(_selection.selectAll('.value'), function(d) {
+                return _tags[sourceHeader + d.key];
+            })
+            .attr('placeholder', function(d) {
+                return t('inspector.source.' + d.key);
+        });
 
+        utilGetSetValue(_selection.selectAll('.main-value'), function() {
+            return _tags[mainKey];
+        });
     }
 
     sources.tags = function(tags){
@@ -230,7 +128,7 @@ export function uiFieldSources(field, context) {
         _tags = tags;
 
         _selection.call(sources);
-    }
+    };
 
     return utilRebind(sources, dispatch, 'on');
 }

--- a/modules/ui/source_subfield.js
+++ b/modules/ui/source_subfield.js
@@ -4,7 +4,6 @@ import {
 
 import { t } from '../core/localizer';
 import { svgIcon } from '../svg/icon';
-import { uiTooltip } from './tooltip';
 import { utilGetSetValue, utilUniqueDomId } from '../util';
 
 export function uiSourceSubfield(context, field, tags, dispatch) {


### PR DESCRIPTION
This PR aims to redesign the "Sources" field for the `source=` and `source:*=` keys.
The main change is the addition of extra rows on the Sources field that each map to a subkey, like `source:name` or `source:url`. In these rows, users will be able to assign values directly to the subkeys, something that was only possible before by manually adding these keys in the tag editor.
![image](https://github.com/user-attachments/assets/3082df2f-f87f-4776-98fa-7cdb01b8b4da)
