### PR TITLE
Replace donation message

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1067,11 +1067,11 @@ en:
     view_on_osm: "View Changes on OHM"
     changeset_id: "Your changeset #: {changeset_id}"
     supporting:
-      title: "OpenHistoricalMap is free to use, but not free to run"
-      details: "Its stability, quality, independence, and strength depend on donations from people like you."
+      title: "More ways to help"
+      details: "OpenHistoricalMap can only exist because of people like you. Here are some other ways you can support the project:"
       donation:
-        title: "Support the map"
-        details: "Any donation will go directly towards keeping OpenStreetMap running."
+        title: "Donate to OpenHistoricalMap"
+        details: "OpenHistoricalMap accepts donations through OpenStreetMap U.S., a 501(c)(3) nonprofit organization based in the United States. Your generous donation will go directly toward keeping OpenHistoricalMap running smoothly for everyone."
     like_osm: "Like OpenHistoricalMap? Connect with others:"
     more: More
     events: Events

--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -189,7 +189,7 @@ export function uiSuccess(context) {
 
     if (showDonationMessage !== false) {
       // support ask
-      const donationUrl = 'https://supporting.openstreetmap.org/';
+      const donationUrl = 'https://openstreetmap.app.neoncrm.com/forms/ohm';
       let supporting = body
         .append('div')
         .attr('class', 'save-supporting');


### PR DESCRIPTION
Replaced the mislabeled OSMF donation link on the post-save screen with the correct link to donate to OHM through OSMUS. Replaced the slogan from openstreetmap/iD#10054 with a more sensitive call to action that avoids rubbing potential donors the wrong way: in this particular context, we want to acknowledge the user’s contribution and encourage them to go further, not guilt them for “using” the project without giving back.

Fixes OpenHistoricalMap/issues#847.