### PR TITLE
Update source prerequisite behavior

### DIFF
--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -63,7 +63,6 @@ function addHistoricalFields(fields) {
 
     for (let i = 1; i < 4; i++){
         let id = 'source:' + i.toString();
-        let previousId = 'source' + ((i-1) > 0 ? ':' + (i-1).toString() : '');
         fields[id] = {
             ...fields.source,
             key: id,
@@ -72,11 +71,25 @@ function addHistoricalFields(fields) {
             baseKey: 'source',
             index: i,
             prerequisiteTag: {
-                keys: [
-                    previousId,
-                    previousId + ':url',
-                    previousId + ':name',
-                    previousId + ':date']}};
+                prerequisiteFunction: (tag) => {
+                    let sourceRegex = /^source/;
+                    if (tag.match(sourceRegex) ){
+                        // allow index 1 if there are any source tags present
+                        if (i === 1){
+                            return true;
+                        } else {
+                            // for index > 1, get the index in the tag with a regex
+                            let indexRegex = /(?<=\:)\d+/;
+                            let regexMatch = parseInt(tag.match(indexRegex), 10);
+                            // allow index i if the index directly before it is present OR if any index above it is present
+                            if (regexMatch === i-1 || regexMatch > i){
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }}
+            };
     }
   }
 

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -72,8 +72,7 @@ function addHistoricalFields(fields) {
             index: i,
             prerequisiteTag: {
                 prerequisiteFunction: (tag) => {
-                    let sourceRegex = /^source/;
-                    if (tag.match(sourceRegex) ){
+                    if (tag.startsWith('source') ){
                         // allow index 1 if there are any source tags present
                         if (i === 1){
                             return true;

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -354,6 +354,10 @@ export function uiField(context, presetField, entityIDs, options) {
 
             if (!entityIDs.every(function(entityID) {
                 var entity = context.graph().entity(entityID);
+                if (prerequisiteTag.prerequisiteFunction) {
+                    // Return true if prerequisiteFunction returns true for any tag
+                    return Object.keys(entity.tags).some(prerequisiteTag.prerequisiteFunction);
+                }
                 if (prerequisiteTag.keys) {
                     // Return true if any key in prerequisiteTag.keys is present, return false otherwise
                     // If prerequisiteTag.keys is present, prerequisiteTag.key will be ignored


### PR DESCRIPTION
Updates the behavior of multiple source fields. Now, a Source i will be visible if `source:i-1` has a non-empty value, or if any source tag with index > i has a non-empty value.
This will ensure all Source fields from 1 to 3 to be visible if `source:3` has a non-empty value