### PR TITLE
Suppress mismatched date warning on identical EDTF date

### DIFF
--- a/modules/validations/mismatched_dates.js
+++ b/modules/validations/mismatched_dates.js
@@ -106,14 +106,16 @@ export function validationMismatchedDates() {
         function validateEDTF(key, msgKey) {
             if (!entity.tags[key] || !entity.tags[key + ':edtf']) return;
             let basic = entity.tags[key];
-            // start_date and end_date disallow time precision. Transform the basic date into a daylong range in EDTF to allow a comparison to an EDTF date with time precision.
-            // https://github.com/OpenHistoricalMap/issues/issues/764
-            if (basic.match('^-?[0-9]+-[0-9]{2}-[0-9]{2}$')) {
-                basic = `${basic}T00:00:00/${basic}T24:00:00`;
-            }
             let basicAsEDTF = parseEDTF(basic);
             let parsed = parseEDTF(entity.tags[key + ':edtf']);
             if (!basicAsEDTF || !parsed || parsed.covers(basicAsEDTF) || basicAsEDTF.covers(parsed)) return;
+
+            // start_date and end_date disallow time precision. Transform the basic date into a daylong range in EDTF to allow a comparison to an EDTF date with time precision.
+            // https://github.com/OpenHistoricalMap/issues/issues/764
+            if (basic.match('^-?[0-9]+-[0-9]{2}-[0-9]{2}$')) {
+                let basicTime = parseEDTF(`${basic}T00:00:00/${basic}T24:00:00`);
+                if (basicTime && (parsed.covers(basicTime) || basicTime.covers(parsed))) return;
+            }
 
             issues.push(new validationIssue({
                 type: type,

--- a/test/spec/validations/mismatched_dates.js
+++ b/test/spec/validations/mismatched_dates.js
@@ -41,6 +41,12 @@ describe('iD.validations.mismatched_dates', function () {
         expect(issues).to.have.lengthOf(0);
     });
 
+    it('ignores way with identical EDTF date', function() {
+        createNode({ shop: 'mall', name: 'Forest Fair Mall', start_date: '1988-07-11', 'start_date:edtf': '1988-07-11', end_date: '2003-06-10', 'end_date:edtf': '2003-06-10' });
+        let issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
     it('flags way with date outside of EDTF range', function() {
         createNode({ natural: 'tree', name: 'The Tree That Owns Itself', start_date: '1901', 'start_date:edtf': '1550~/1900~', end_date: '1942' });
         let issues = validate();


### PR DESCRIPTION
This fixes the spurious mismatched date warnings introduced in #220 when the `start_date=*` or `end_date=*` falls on the last day of the `start_date:edtf=*` or `end_date:edtf=*` date range, respectively.

Fixes OpenHistoricalMap/issues#970.