### PR TITLE
Shorten validator error message when EDTF date starts with invalid character

### DIFF
--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -102,7 +102,7 @@ export function validationFormatting() {
 
         function showReferenceEDTF(selection, parserError) {
             let message;
-            if (parserError.offset && parserError.token) {
+            if (typeof parserError.offset === 'number' && parserError.token) {
                 message = t.append('issues.invalid_format.edtf.reference', {
                     token: parserError.token.value,
                     position: (parserError.offset + 1).toLocaleString(localizer.localeCodes()),


### PR DESCRIPTION
We have code to pretty-print EDTF.js’s extremely verbose error messages, but it wasn’t kicking in because we were incorrectly treating an offset of 0 as a missing offset.

Fixes OpenHistoricalMap/issues#715.