### PR TITLE
EDTF.js v4.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openhistoricalmap/id",
-  "version": "2.29.0-dev",
+  "version": "2.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openhistoricalmap/id",
-      "version": "2.29.0-dev",
+      "version": "2.29.1",
       "license": "ISC",
       "dependencies": {
         "@mapbox/geojson-area": "^0.2.2",
@@ -22,7 +22,7 @@
         "alif-toolkit": "^1.2.9",
         "core-js-bundle": "^3.36.1",
         "diacritics": "1.3.0",
-        "edtf": "^4.5.1",
+        "edtf": "^4.7.1",
         "exifr": "^7.1.3",
         "fast-deep-equal": "~3.1.1",
         "fast-json-stable-stringify": "2.1.0",
@@ -3324,9 +3324,10 @@
       "license": "BSD"
     },
     "node_modules/edtf": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/edtf/-/edtf-4.6.0.tgz",
-      "integrity": "sha512-teU7GwHONv5v9L3PGXlki7d/ISi2HFxXbXSGx0mWh7Lq7ezYmxkmDYVKzBXdhFjhvASEUnDontPvGzIlYASYRA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/edtf/-/edtf-4.7.1.tgz",
+      "integrity": "sha512-s2V0L8dhNX7c5OHU0N3Qi7Qb/QHaleJtVlfFHG8e/0La+kZcz8+EkDuyZ1uue4bVDt4cYZp32c87cZPmBee+2Q==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "nearley": "^2.19.7"
       },
@@ -11227,9 +11228,9 @@
       "from": "editor-layer-index@github:osmlab/editor-layer-index#gh-pages"
     },
     "edtf": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/edtf/-/edtf-4.6.0.tgz",
-      "integrity": "sha512-teU7GwHONv5v9L3PGXlki7d/ISi2HFxXbXSGx0mWh7Lq7ezYmxkmDYVKzBXdhFjhvASEUnDontPvGzIlYASYRA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/edtf/-/edtf-4.7.1.tgz",
+      "integrity": "sha512-s2V0L8dhNX7c5OHU0N3Qi7Qb/QHaleJtVlfFHG8e/0La+kZcz8+EkDuyZ1uue4bVDt4cYZp32c87cZPmBee+2Q==",
       "requires": {
         "nearley": "^2.19.7",
         "randexp": "^0.5.3"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "alif-toolkit": "^1.2.9",
     "core-js-bundle": "^3.36.1",
     "diacritics": "1.3.0",
-    "edtf": "^4.5.1",
+    "edtf": "^4.7.1",
     "exifr": "^7.1.3",
     "fast-deep-equal": "~3.1.1",
     "fast-json-stable-stringify": "2.1.0",


### PR DESCRIPTION
Upgraded EDTF.js from v4.5.1 to v4.7.1, which includes the EDTF level 3 enhancements in [the changelog](https://github.com/inukshuk/edtf.js/blob/main/CHANGELOG.md#470--2025-01-18).