### PR TITLE
Append date range to unnamed non-route labels

### DIFF
--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -197,7 +197,7 @@ export function utilDisplayName(entity, hideNetwork, isMapLabel) {
     // https://github.com/OpenHistoricalMap/issues/issues/470
     //return name && dateRange ? t('inspector.display_name.dated', {dateRange: dateRange, name: name}) : name;
     const appendDateRange = (name, dateRange) => {
-        return dateRange ? `${name} [${dateRange}]` : name;
+        return dateRange ? `${name} [${dateRange}]`.trim() : name;
     };
 
     var localizedNameKey = 'name:' + localizer.languageCode().toLowerCase();
@@ -335,7 +335,7 @@ export function utilDisplayName(entity, hideNetwork, isMapLabel) {
     }
 
     // no match found
-    return '';
+    return appendDateRange('', dateRange);
 }
 
 

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -363,6 +363,9 @@ describe('iD.util', function() {
             expect(iD.utilDisplayName({tags: {name: 'Capitol Christmas Tree', start_date: '2021-11-19', end_date: '2021-12-25'}})).to.eql('Capitol Christmas Tree [2021]');
             expect(iD.utilDisplayName({tags: {name: 'Binary Search Tree', start_date: '0b0110', end_date: '0b0110'}})).to.eql('Binary Search Tree');
         });
+        it('appends a date range even if unnamed', function() {
+            expect(iD.utilDisplayName({tags: {start_date: '1988-03-01'}})).to.eql('[1988 – ]');
+        });
     });
 
     describe('utilOldestID', function() {


### PR DESCRIPTION
Append the date range to the label of an unnamed non-route element. The empty string remains the last resort if there’s no date range.

Before | After
----|----
<img width="359" height="77" alt="Site" src="https://github.com/user-attachments/assets/dd63b85f-dd69-4134-9d33-3e102b073be1" /> | <img width="359" height="72" alt="Site [1988 – ]" src="https://github.com/user-attachments/assets/15d07991-b17e-4e40-9daf-300d57397404" />
<img width="400" height="300" alt="Unlabeled trees" src="https://github.com/user-attachments/assets/7215d649-f96f-4068-a450-81dfd83448f7" /> | <img width="400" height="300" alt="Trees labeled [1988 – ]" src="https://github.com/user-attachments/assets/48c67416-2438-4dec-9cea-52d2c5279ab5" />

Fixes OpenHistoricalMap/issues#1274.