### PR TITLE
Remove short-circuit when filtering features by category

### DIFF
--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -612,7 +612,7 @@ export function rendererFeatures(context) {
 
 
     features.filter = function(d, resolver) {
-        if (!_hidden.length) return d;
+        // if (!_hidden.length) return d;
 
         var result = [];
         for (var i = 0; i < d.length; i++) {

--- a/test/spec/renderer/features.js
+++ b/test/spec/renderer/features.js
@@ -613,6 +613,7 @@ describe('iD.rendererFeatures', function() {
             expect(features.isHidden(b, graph, bgeo)).to.be.false;
             expect(features.isHidden(c, graph, cgeo)).to.be.true;
             expect(features.dateMatchCount()).to.eql(1);
+            expect(features.filter([a, b, c], graph)).to.deep.equal([a, b]);
         });
 
         it('#forceVisible', function() {


### PR DESCRIPTION
Always evaluate each feature individually for whether it matches the date filter, even if none of the feature categories is hidden.

Fixes OpenHistoricalMap/issues#1280.