### PR TITLE
Distinguish source fields between changesets and presets

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -826,6 +826,7 @@ en:
     field_source: add source
     field_source_label: Source for {field_name}
     field_source_placeholder: URL, newspaper article, book...
+    indexed_field_label: "{field_name} ({index})"
     source:
       main_input: Description
       name: Name
@@ -2357,10 +2358,8 @@ en:
         label: License
         placeholder: CC0
         terms: copyleft, copyright
-      source:
+      source_preset:
         label: Source
-      source_multiple:
-        label: Source {index}
     presets:
       type/chronology:
         name: Chronology

--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -10,12 +10,6 @@ export function presetField(fieldID, field, allFields) {
   allFields = allFields || {};
   let _this = Object.assign({}, field);   // shallow copy
 
-  // This handles fields that are composed of a base key and an index, like 'source:1'
-  let localizerFieldID = fieldID;
-  if (field.baseKey && field.index){
-    localizerFieldID = field.baseKey + '_multiple';
-  }
-
   _this.id = fieldID;
 
   // for use in classes, element ids, css selectors
@@ -27,14 +21,14 @@ export function presetField(fieldID, field, allFields) {
     return !_this.geometry || geometries.every(geom => _this.geometry.indexOf(geom) !== -1);
   };
 
-  _this.t = (scope, options) => t(localizer.coalesceStringIds([`custom_presets.fields.${localizerFieldID}.${scope}`,
-                                                               `_tagging.presets.fields.${localizerFieldID}.${scope}`]), options);
-  _this.t.html = (scope, options) => t.html(localizer.coalesceStringIds([`custom_presets.fields.${localizerFieldID}.${scope}`,
-                                                                         `_tagging.presets.fields.${localizerFieldID}.${scope}`]), options);
-  _this.t.append = (scope, options) => t.append(localizer.coalesceStringIds([`custom_presets.fields.${localizerFieldID}.${scope}`,
-                                                                             `_tagging.presets.fields.${localizerFieldID}.${scope}`]), options);
-  _this.hasTextForStringId = (scope) => localizer.hasTextForStringId(`custom_presets.fields.${localizerFieldID}.${scope}`) ||
-    localizer.hasTextForStringId(`_tagging.presets.fields.${localizerFieldID}.${scope}`);
+  _this.t = (scope, options) => t(localizer.coalesceStringIds([`custom_presets.fields.${fieldID}.${scope}`,
+                                                               `_tagging.presets.fields.${fieldID}.${scope}`]), options);
+  _this.t.html = (scope, options) => t.html(localizer.coalesceStringIds([`custom_presets.fields.${fieldID}.${scope}`,
+                                                                         `_tagging.presets.fields.${fieldID}.${scope}`]), options);
+  _this.t.append = (scope, options) => t.append(localizer.coalesceStringIds([`custom_presets.fields.${fieldID}.${scope}`,
+                                                                             `_tagging.presets.fields.${fieldID}.${scope}`]), options);
+  _this.hasTextForStringId = (scope) => localizer.hasTextForStringId(`custom_presets.fields.${fieldID}.${scope}`) ||
+    localizer.hasTextForStringId(`_tagging.presets.fields.${fieldID}.${scope}`);
 
   _this.resolveReference = which => {
     const referenceRegex = /^\{(.*)\}$/;
@@ -49,10 +43,36 @@ export function presetField(fieldID, field, allFields) {
     return _this;
   };
 
-  _this.title = () => _this.overrideLabel || _this.resolveReference('label').t('label', { 'default': fieldID, 'index': field.index });
-  _this.label = () => _this.overrideLabel ?
-      selection => selection.text(_this.overrideLabel) :
-      _this.resolveReference('label').t.append('label', { 'default': fieldID, 'index': field.index });
+    _this.title = () => {
+      if (_this.overrideLabel) {
+        return _this.overrideLabel;
+      }
+      if (field.index) {
+        let baseLabel = _this.resolveReference('stringsCrossReference').t('label', { 'default': fieldID });
+        let index = field.index.toLocaleString(localizer.localeCode());
+        return t('inspector.indexed_field_label', {
+          'default': `${baseLabel} (${index})`,
+          field_name: baseLabel,
+          index,
+        });
+      }
+      return _this.resolveReference('label').t('label', { 'default': fieldID });
+    };
+    _this.label = () => {
+      if (_this.overrideLabel) {
+        return selection => selection.text(_this.overrideLabel);
+      }
+      if (field.index) {
+        let baseLabel = _this.resolveReference('stringsCrossReference').t('label', { 'default': fieldID });
+        let index = field.index.toLocaleString(localizer.localeCode());
+        return t.append('inspector.indexed_field_label', {
+          'default': `${baseLabel} (${index})`,
+          field_name: baseLabel,
+          index,
+        });
+      }
+      return _this.resolveReference('label').t.append('label', { 'default': fieldID });
+    };
 
   _this.placeholder = () => _this.resolveReference('placeholder').t('placeholder', { 'default': '' });
 

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -55,28 +55,36 @@ function addHistoricalFields(fields) {
     };
   }
 
-  // A combo box would encourage mappers to choose one of the suggestions, but we want mappers to be as detailed as possible.
   if (fields.source) {
-    fields.source.type = 'source';
+    // No need to provide a source for a source.
     fields.source.source = false;
-    fields.source.keys = ['source', 'source:url', 'source:name', 'source:date'];
+
+    // A combo box would encourage mappers to choose one of the suggestions, but we want mappers to be as detailed as possible.
+    // Reserve the simple combo box for the changeset editor, which populates the field via the API.
+    const subkeys = ['', ':url', ':name', ':date'];
+    fields.source_preset = {
+      ...fields.source,
+      id: 'source_preset',
+      type: 'source',
+      usage: 'preset',
+      keys: subkeys.map(sk => `source${sk}`)
+    };
 
     for (let i = 1; i < 4; i++){
-        let id = 'source:' + i.toString();
-        let previousId = 'source' + ((i-1) > 0 ? ':' + (i-1).toString() : '');
-        fields[id] = {
-            ...fields.source,
-            key: id,
-            keys: [id, id + ':url', id + ':name', id + ':date'],
-            // baseKey and index will be used to create a localized label for this field
-            baseKey: 'source',
-            index: i,
-            prerequisiteTag: {
-                keys: [
-                    previousId,
-                    previousId + ':url',
-                    previousId + ':name',
-                    previousId + ':date']}};
+      const id = `source_preset:${i}`;
+      const key = `source:${i}`;
+      fields[id] = {
+        ...fields.source_preset,
+        id,
+        key,
+        keys: subkeys.map(sk => `${key}${sk}`),
+        // stringsCrossReference and index will be used to create a localized label for this field
+        stringsCrossReference: '{source_preset}',
+        index: i,
+        prerequisiteTag: {
+          keys: subkeys.map(sk => `source${((i-1) > 0 ? ':' + (i-1) : '')}${sk}`)
+        }
+      };
     }
   }
 

--- a/modules/ui/sections/preset_fields.js
+++ b/modules/ui/sections/preset_fields.js
@@ -70,7 +70,7 @@ export function uiSectionPresetFields(context) {
             _fieldsArr = [];
 
             // Ideally, everything in OpenHistoricalMap is dated and sourced.
-            let coreKeys = ['start_date', 'end_date', 'source'];
+            let coreKeys = ['start_date', 'end_date', 'source_preset'];
             coreKeys.forEach(key => {
                 let field = presetsManager.field(key);
                 if (field) {
@@ -78,7 +78,7 @@ export function uiSectionPresetFields(context) {
                 }
             });
 
-            let optionalCoreKeys = ['source:1', 'source:2', 'source:3'];
+            let optionalCoreKeys = ['source_preset:1', 'source_preset:2', 'source_preset:3'];
             optionalCoreKeys.forEach(key => {
                 let field = presetsManager.field(key);
                 if (field && !_fieldsArr.includes(field)) {


### PR DESCRIPTION
Copied id-tagging-schema’s Sources field into a separate Source field for use in presets, leaving the Sources field largely unmodified. Also simplified the code to generate indexed variants of the Source field. This effectively restores the original combo box Sources field to the changeset editor, where we haven’t implemented multiple source fields and don’t expect as much source metadata as on elements. iD does some magic with the changeset-only Sources field that we don’t want to get in the way of.

Fields that can appear multiple times now use `stringsCrossReference` to inherit the label from the original base field with the index appended, all independently of the raw key. Added parentheses around the index in the label and localize it according to the current locale’s numeral system.

<img width="399" height="573" alt="Source, Source (1), Source (2)" src="https://github.com/user-attachments/assets/f6632147-09a0-464b-a773-12b628e0405d" /> <img width="399" height="430" alt="Nguồn with a dropdown of preset options plus gpx." src="https://github.com/user-attachments/assets/4b9fd0b0-cc65-45e5-9266-e62b492f4a26" />

Fixes OpenHistoricalMap/issues#1275.